### PR TITLE
Fix custom element registration

### DIFF
--- a/src/components/Likes.astro
+++ b/src/components/Likes.astro
@@ -212,7 +212,9 @@ const { count, slug } = Astro.props
     }
   }
 
-  customElements.define('post-likes', Likes)
+  if (!customElements.get('post-likes')) {
+    customElements.define('post-likes', Likes)
+  }
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- avoid redefining the `post-likes` custom element in `Likes.astro`

## Testing
- `npx vitest run` *(fails: EHOSTUNREACH when attempting to download packages)*
