### PR TITLE
Add error timer test

### DIFF
--- a/src/components/__tests__/Likes.test.ts
+++ b/src/components/__tests__/Likes.test.ts
@@ -44,6 +44,7 @@ describe('Likes Component', () => {
   afterEach(() => {
     // Cleanup
     container?.remove()
+    vi.useRealTimers()
   })
 
   const getCountElement = () => {
@@ -179,6 +180,20 @@ describe('Likes Component', () => {
       expect(button.getAttribute('aria-label')).toContain(
         'Click to unlike this post',
       )
+    })
+  })
+
+  it('should show and clear error state after timeout', async () => {
+    vi.useFakeTimers()
+    mountComponent({ count: 0, slug: 'test-post' })
+    const button = screen.getByRole('button')
+
+    ;(container as any).showError('boom')
+    expect(button.classList.contains('error')).toBe(true)
+
+    vi.advanceTimersByTime(2000)
+    await waitFor(() => {
+      expect(button.classList.contains('error')).toBe(false)
     })
   })
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -104,5 +104,15 @@ customElements.define(
         console.error(error)
       }
     }
+
+    showError(message: string) {
+      console.error(message)
+      if (this.likeButton) {
+        this.likeButton.classList.add('error')
+        setTimeout(() => {
+          this.likeButton?.classList.remove('error')
+        }, 2000)
+      }
+    }
   },
 )


### PR DESCRIPTION
## Summary
- extend test component setup with `showError`
- ensure timers restored in Like tests
- add a new test that verifies error class removal after timeout

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails to start due to missing dependencies)*