### PR TITLE
Switch to native ViewTransition API

### DIFF
--- a/src/components/BlogHero.astro
+++ b/src/components/BlogHero.astro
@@ -23,7 +23,7 @@ const description = subtitle
   <Header />
   <div class="region wrapper">
     <div class="flex flex-col justify-center flow prose text-gray-100">
-      <h1 transition:name={'blog' + title}>{title}</h1>
+      <h1 style={`view-transition-name: blog${title}`}>{title}</h1>
       <h2 class="font-regular">{description}</h2>
     </div>
   </div>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,6 +1,5 @@
 ---
 import '../css/global.css'
-import { ClientRouter } from 'astro:transitions'
 import type { Header } from '@types'
 
 export interface Props extends Header {}
@@ -18,7 +17,6 @@ const ogImage = meta.image
 ---
 
 <head>
-  <ClientRouter />
   <!-- Meta -->
   <meta charset="UTF-8" />
   <meta name="description" content={description} />
@@ -191,5 +189,23 @@ const ogImage = meta.image
     gtag('js', new Date())
 
     gtag('config', 'G-NJMVWJT1D7')
+  </script>
+  <script>
+    if (document.startViewTransition) {
+      const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)')
+      addEventListener('click', (event) => {
+        const anchor = (event.target as HTMLElement).closest('a')
+        if (!anchor) return
+        if (anchor.target && anchor.target !== '_self') return
+        const url = new URL(anchor.href)
+        if (url.origin !== location.origin) return
+        if (url.pathname === location.pathname && url.search === location.search) return
+        if (reduceMotion.matches) return
+        event.preventDefault()
+        document.startViewTransition(() => {
+          location.href = anchor.href
+        })
+      })
+    }
   </script>
 </head>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -121,8 +121,8 @@
   const fadeInUpFrom = { opacity: 0, y: -20 }
   const fadeInUpTo = { opacity: 1, y: 0, duration: 0.5 }
 
-  // Run animation when view transition is complete
-  document.addEventListener('astro:page-load', () => {
+  // Run animation on page load
+  document.addEventListener('DOMContentLoaded', () => {
     const prefersReducedMotion = window.matchMedia(
       '(prefers-reduced-motion: reduce)'
     )

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -37,7 +37,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
             <h3 class="mt-zero">
               <a
                 href={`/${post.collection}/${post.id}/`}
-                transition:name={'blog' + post.data.title}
+                style={`view-transition-name: blog${post.data.title}`}
               >
                 {post.data.title}
               </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ function truncateDescription(description: string) {
               <h3 class="mt-zero">
                 <a
                   href={`/${post.collection}/${post.id}/`}
-                  transition:name={'blog' + post.data.title}
+                  style={`view-transition-name: blog${post.data.title}`}
                 >
                   {post.data.title}
                 </a>


### PR DESCRIPTION
## Summary
- remove `ClientRouter` and Astro view transition hooks
- implement a small View Transition script using the browser API
- trigger header animation on DOM load instead of Astro events
- apply `view-transition-name` styling for heading links

## Testing
- `npm test` *(fails: vitest not found)*