### PR TITLE
fix: simplify like state updates

### DIFF
--- a/src/components/Likes.astro
+++ b/src/components/Likes.astro
@@ -132,28 +132,23 @@ const { count, slug } = Astro.props
       // Store initial state for rollback
       const initialCount = this.count
       const wasLiked = this.liked
+      const desiredLiked = !this.liked
 
       // Optimistic update
-      this.liked = !this.liked
-      this.count = this.liked ? this.count + 1 : this.count - 1
+      this.liked = desiredLiked
+      this.count = this.liked ? this.count + 1 : Math.max(0, this.count - 1)
       this.updateUI()
       this.animateFeedback()
 
       try {
-        const response = await this.sendLikeRequest()
+        const response = await this.sendLikeRequest(desiredLiked)
 
         if (!response.ok) {
           const error = (await response.json()) as APIError
           throw new Error(error.message || 'Server error')
         }
 
-        const { liked, count } = (await response.json()) as LikeResponse
-        if (typeof liked === 'boolean') {
-          this.liked = liked
-        }
-        if (typeof count === 'number') {
-          this.count = count
-        }
+        this.applyServerState((await response.json()) as LikeResponse)
         this.updateUI()
       } catch (error) {
         // Revert on error
@@ -164,24 +159,46 @@ const { count, slug } = Astro.props
       }
     }
 
-    private async sendLikeRequest(): Promise<Response> {
+    private async sendLikeRequest(liked: boolean): Promise<Response> {
       return fetch(`/api/like-post/${this.slug}/`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ slug: this.slug }),
+        body: JSON.stringify({ slug: this.slug, liked }),
       })
     }
 
     private async hydrateLikedState() {
+      this.isUpdating = true
       this.likeButton.disabled = true
       try {
         await this.updateLikedState()
-      } finally {
         this.isUpdating = false
         this.likeButton.disabled = false
+      } catch (error) {
+        console.error('Error fetching like state:', error)
+        this.showError('Failed to load like status')
+        this.setUnavailableState()
       }
+    }
+
+    private applyServerState({ liked, count }: LikeResponse) {
+      if (typeof liked === 'boolean') {
+        this.liked = liked
+      }
+      if (typeof count === 'number') {
+        this.count = count
+      }
+    }
+
+    private setUnavailableState() {
+      this.isUpdating = true
+      this.likeButton.disabled = true
+      this.likeButton.setAttribute(
+        'aria-label',
+        'Likes are unavailable right now.',
+      )
     }
 
     private updateUI() {
@@ -233,30 +250,19 @@ const { count, slug } = Astro.props
     }
 
     private async updateLikedState() {
-      try {
-        const response = await fetch(`/api/like-post/${this.slug}/`, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        })
+      const response = await fetch(`/api/like-post/${this.slug}/`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
 
-        if (!response.ok) {
-          throw new Error('Failed to fetch like state')
-        }
-
-        const { liked, count } = (await response.json()) as LikeResponse
-        if (typeof liked === 'boolean') {
-          this.liked = liked
-        }
-        if (typeof count === 'number') {
-          this.count = count
-        }
-        this.updateUI()
-      } catch (error) {
-        console.error('Error fetching like state:', error)
-        this.showError('Failed to load like status')
+      if (!response.ok) {
+        throw new Error('Failed to fetch like state')
       }
+
+      this.applyServerState((await response.json()) as LikeResponse)
+      this.updateUI()
     }
 
     private showError(message: string) {

--- a/src/components/__tests__/Likes.test.ts
+++ b/src/components/__tests__/Likes.test.ts
@@ -55,6 +55,7 @@ describe('Likes Component', () => {
     // Cleanup
     container?.remove()
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   const getCountElement = () => {
@@ -112,7 +113,7 @@ describe('Likes Component', () => {
     })
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ count: initialCount + 1 }),
+      json: () => Promise.resolve({ liked: true, count: initialCount + 1 }),
     })
 
     mountComponent({ count: initialCount, slug: 'test-post' })
@@ -127,6 +128,41 @@ describe('Likes Component', () => {
       expect(countElement.textContent).toContain((initialCount + 1).toString())
       expect(container.classList.contains('bg-gray-1400')).toBe(true)
     })
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      '/api/like-post/test-post/',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ slug: 'test-post', liked: true }),
+      }),
+    )
+  })
+
+  it('should send the desired unlike state on click', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ liked: true, count: 5 }),
+    })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ liked: false, count: 4 }),
+    })
+
+    mountComponent({ count: 5, slug: 'test-post' })
+    const button = await waitForReady()
+
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(getCountElement()).toHaveTextContent('4')
+      expect(button.getAttribute('aria-label')).toContain('Click to like')
+    })
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      '/api/like-post/test-post/',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ slug: 'test-post', liked: false }),
+      }),
+    )
   })
 
   it('should revert UI on failed like request', async () => {
@@ -252,8 +288,40 @@ describe('Likes Component', () => {
     })
   })
 
+  it('should keep likes disabled when the initial liked state fails', async () => {
+    vi.useFakeTimers()
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ available: false }),
+    })
+
+    mountComponent({ count: 2, slug: 'test-post' })
+    const button = screen.getByRole('button')
+
+    await waitFor(() => {
+      expect(button).toBeDisabled()
+      expect(button.getAttribute('aria-label')).toBe(
+        'Likes are unavailable right now.',
+      )
+      expect(button.classList.contains('error')).toBe(true)
+    })
+
+    vi.advanceTimersByTime(2000)
+    await waitFor(() => {
+      expect(button).toBeDisabled()
+      expect(button.classList.contains('error')).toBe(false)
+    })
+    expect(consoleError).toHaveBeenCalled()
+  })
+
   it('should show and clear error state after timeout', async () => {
     vi.useFakeTimers()
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
     mountComponent({ count: 0, slug: 'test-post' })
     const button = screen.getByRole('button')
 
@@ -264,5 +332,6 @@ describe('Likes Component', () => {
     await waitFor(() => {
       expect(button.classList.contains('error')).toBe(false)
     })
+    expect(consoleError).toHaveBeenCalledWith('boom')
   })
 })

--- a/src/pages/api/like-post/[slug].ts
+++ b/src/pages/api/like-post/[slug].ts
@@ -15,68 +15,67 @@ const jsonResponse = (body: Record<string, unknown>, status = 200) =>
     headers: JSON_HEADERS,
   })
 
+const databaseUnavailableResponse = () =>
+  jsonResponse(
+    {
+      message: 'Database unavailable',
+      reason: dbStatus.error ?? 'Unknown database init error',
+      available: false,
+    },
+    503,
+  )
+
 /**
- * Handles a POST request to like a post.
+ * Handles a POST request to set a post's liked state.
  * @param params - The parameters from the request URL.
  * @param request - The incoming request object.
  * @param clientAddress - The IP address of the client making the request.
- * @returns A response indicating the success of the like operation.
+ * @returns A response indicating the current liked state and count.
  */
 export const POST: APIRoute = async ({ params, request, clientAddress }) => {
-  // get slug of liked item assuming a request like `/api/like-post/[slug].ts`
   const { slug } = params
   if (!slug) {
     return jsonResponse({ message: 'Slug is required' }, 400)
   }
 
   if (!db) {
-    return jsonResponse(
-      {
-        message: 'Database unavailable',
-        reason: dbStatus.error ?? 'Unknown database init error',
-      },
-      503,
-    )
+    return databaseUnavailableResponse()
   }
 
   const database = db
+  let desiredLiked: unknown
+
+  try {
+    const body = (await request.json()) as { liked?: unknown }
+    desiredLiked = body.liked
+  } catch {
+    return jsonResponse({ message: 'Request body must be JSON' }, 400)
+  }
+
+  if (typeof desiredLiked !== 'boolean') {
+    return jsonResponse({ message: 'liked must be a boolean' }, 400)
+  }
 
   const userAgent = request.headers.get('user-agent') ?? 'unknown'
   const clientId =
     clientAddress ?? request.headers.get('x-forwarded-for') ?? 'unknown'
-  // hash the UA, IP address, and liked post slug to create a unique ID
   const id = await digest(`${userAgent}:${clientId}:${slug}`)
-  // insert the like and ignore it if it was already set
-  if (id && slug) {
-    // check if the like already exists in the database
-    const existingLike = await database
-      .select()
-      .from(Like)
-      .where(eq(Like.id, id))
-    // if the like exists, remove it from the database
-    if (existingLike.length > 0) {
-      await database.delete(Like).where(eq(Like.id, id))
-      // Grab the current count of likes for the post
-      const count = await countCurrentPostLikes(database, slug)
-      return jsonResponse(
-        {
-          message: 'Successfully removed like!',
-          liked: false,
-          count,
-        },
-        200,
-      )
-    }
-    // insert the like and ignore it if it was already set
+
+  if (desiredLiked) {
     await database.insert(Like).values({ id, slug }).onConflictDoNothing()
+  } else {
+    await database.delete(Like).where(eq(Like.id, id))
   }
-  // return a response
+
   const count = await countCurrentPostLikes(database, slug)
   return jsonResponse(
     {
-      message: 'Successfully liked!',
-      liked: true,
+      message: desiredLiked
+        ? 'Successfully liked!'
+        : 'Successfully removed like!',
+      liked: desiredLiked,
       count,
+      available: true,
     },
     200,
   )
@@ -97,13 +96,7 @@ export const GET: APIRoute = async ({ params, request, clientAddress }) => {
   }
 
   if (!db) {
-    return jsonResponse(
-      {
-        message: 'Database unavailable',
-        reason: dbStatus.error ?? 'Unknown database init error',
-      },
-      503,
-    )
+    return databaseUnavailableResponse()
   }
 
   const database = db
@@ -121,6 +114,7 @@ export const GET: APIRoute = async ({ params, request, clientAddress }) => {
     {
       liked: existingLike.length > 0,
       count,
+      available: true,
     },
     200,
   )

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -37,17 +37,18 @@ customElements.define(
 
         const initialCount = this.count
         const wasLiked = this.liked
+        const desiredLiked = !this.liked
         this.isUpdating = true
         if (this.likeButton) {
           this.likeButton.disabled = true
         }
 
         // Optimistic update
-        this.liked = !this.liked
+        this.liked = desiredLiked
         if (this.liked) {
           this.count++
         } else {
-          this.count--
+          this.count = Math.max(0, this.count - 1)
         }
         this.updateUI()
 
@@ -57,20 +58,17 @@ customElements.define(
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ slug: this.dataset.slug }),
+            body: JSON.stringify({
+              slug: this.dataset.slug,
+              liked: desiredLiked,
+            }),
           })
 
           if (!response.ok) {
             throw new Error('Server error')
           }
 
-          const { liked, count } = await response.json()
-          if (typeof liked === 'boolean') {
-            this.liked = liked
-          }
-          if (typeof count === 'number') {
-            this.count = count
-          }
+          this.applyServerState(await response.json())
           this.updateUI()
         } catch (error) {
           // Revert on error
@@ -113,39 +111,56 @@ customElements.define(
     }
 
     async hydrateLikedState() {
+      this.isUpdating = true
       if (this.likeButton) {
         this.likeButton.disabled = true
       }
       try {
         await this.updateLikedState()
-      } finally {
         this.isUpdating = false
         if (this.likeButton) {
           this.likeButton.disabled = false
         }
+      } catch (error) {
+        console.error(error)
+        this.showError('Failed to load like status')
+        this.setUnavailableState()
       }
     }
 
     async updateLikedState() {
-      try {
-        const response = await fetch(`/api/like-post/${this.dataset.slug}/`, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        })
-        if (response.ok) {
-          const { liked, count } = await response.json()
-          if (typeof liked === 'boolean') {
-            this.liked = liked
-          }
-          if (typeof count === 'number') {
-            this.count = count
-          }
-          this.updateUI()
-        }
-      } catch (error) {
-        console.error(error)
+      const response = await fetch(`/api/like-post/${this.dataset.slug}/`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch like state')
+      }
+
+      this.applyServerState(await response.json())
+      this.updateUI()
+    }
+
+    applyServerState({ liked, count }: { liked?: unknown; count?: unknown }) {
+      if (typeof liked === 'boolean') {
+        this.liked = liked
+      }
+      if (typeof count === 'number') {
+        this.count = count
+      }
+    }
+
+    setUnavailableState() {
+      this.isUpdating = true
+      if (this.likeButton) {
+        this.likeButton.disabled = true
+        this.likeButton.setAttribute(
+          'aria-label',
+          'Likes are unavailable right now.',
+        )
       }
     }
 


### PR DESCRIPTION
## Summary
The like button now asks the server to set an explicit final state, so the UI no longer depends on a fragile client/server toggle guess. The button also stays disabled when the initial database-backed state cannot load, while preserving the existing wiggle feedback for that failure state.

The API now returns a consistent liked/count/availability response shape, and the component reconciles from that server state after both hydration and clicks.

## Test Plan
- `npm run test:run`
- `npm run build`
- `npx prettier --check src/components/Likes.astro src/components/__tests__/Likes.test.ts 'src/pages/api/like-post/[slug].ts' vitest.setup.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
