### PR TITLE
feat: add llms.txt site guide

### DIFF
--- a/src/lib/llms-txt.test.ts
+++ b/src/lib/llms-txt.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLlmsTxt, type LlmsPost } from './llms-txt'
+
+const site = new URL('https://frankstall.one')
+
+function createPost(
+  id: string,
+  publishDate: string,
+  options: { isDraft?: boolean; description?: string } = {},
+): LlmsPost {
+  return {
+    id,
+    data: {
+      title: `Post ${id}`,
+      description: options.description ?? `Description for ${id}`,
+      publishDate: new Date(publishDate),
+      isDraft: options.isDraft ?? false,
+    },
+  }
+}
+
+describe('buildLlmsTxt', () => {
+  it('builds a spec-shaped guide with absolute links to the key site content', () => {
+    const result = buildLlmsTxt([createPost('recent-post', '2026-06-01')], site)
+    const curatedPaths = [
+      '/',
+      '/portfolio/',
+      '/blog/',
+      '/portfolio/klaviyo-asecnt-design-system-phone-input/',
+      '/portfolio/klaviyo-asecnt-design-system-documentation-site/',
+      '/portfolio/design-system-lead-simpson-strong-tie/',
+      '/portfolio/roll-by-adp/',
+      '/portfolio/btc/',
+      '/portfolio/loumarc-signs/',
+      '/uses/',
+      '/accessibility-statement/',
+      '/archives/',
+    ]
+
+    expect(result.startsWith('# Frank Stallone\n\n> Designer, developer')).toBe(
+      true,
+    )
+    expect(result).toContain('## Start here')
+    expect(result).toContain(
+      '- [Portfolio](https://frankstall.one/portfolio/): Selected product, brand, and design-system work',
+    )
+    expect(result).toContain('## Selected case studies')
+    expect(result).toContain('## Recent writing')
+    expect(result).toContain('## Optional')
+    curatedPaths.forEach((path) => {
+      expect(result).toContain(new URL(path, site).href)
+    })
+    expect(result).toContain(
+      '- [Post recent-post](https://frankstall.one/blog/recent-post/): Description for recent-post',
+    )
+    expect(result.endsWith('\n')).toBe(true)
+  })
+
+  it('lists only the six newest published posts without mutating the collection', () => {
+    const posts = [
+      createPost('oldest', '2026-01-01'),
+      createPost('newest-draft', '2026-12-01', { isDraft: true }),
+      createPost('second', '2026-06-01'),
+      createPost('third', '2026-05-01'),
+      createPost('fourth', '2026-04-01'),
+      createPost('fifth', '2026-03-01'),
+      createPost('sixth', '2026-02-01'),
+      createPost('newest', '2026-07-01'),
+    ]
+    const originalOrder = posts.map((post) => post.id)
+
+    const result = buildLlmsTxt(posts, site)
+
+    expect(result).not.toContain('newest-draft')
+    expect(result).not.toContain('oldest')
+    expect(result.indexOf('newest/')).toBeLessThan(result.indexOf('second/'))
+    expect(posts.map((post) => post.id)).toEqual(originalOrder)
+  })
+
+  it('normalizes multiline descriptions so each file-list item stays on one line', () => {
+    const result = buildLlmsTxt(
+      [
+        createPost('multiline', '2026-06-01', {
+          description: 'A description\nwith extra   spacing.',
+        }),
+      ],
+      site,
+    )
+
+    expect(result).toContain(': A description with extra spacing.')
+  })
+})

--- a/src/lib/llms-txt.ts
+++ b/src/lib/llms-txt.ts
@@ -1,0 +1,145 @@
+import type { CollectionEntry } from 'astro:content'
+
+export type LlmsPost = Pick<CollectionEntry<'blog'>, 'id' | 'data'>
+
+type CuratedLink = {
+  title: string
+  path: string
+  description: string
+}
+
+const RECENT_POST_LIMIT = 6
+
+const START_HERE_LINKS: CuratedLink[] = [
+  {
+    title: 'Home',
+    path: '/',
+    description:
+      'Overview, recent writing, portfolio highlights, and an introduction to Frank',
+  },
+  {
+    title: 'Portfolio',
+    path: '/portfolio/',
+    description: 'Selected product, brand, and design-system work',
+  },
+  {
+    title: 'Blog',
+    path: '/blog/',
+    description:
+      'Writing about design, systems, craft, accessibility, and web development',
+  },
+]
+
+const CASE_STUDY_LINKS: CuratedLink[] = [
+  {
+    title: 'Klaviyo Ascent Design System: Phone input',
+    path: '/portfolio/klaviyo-asecnt-design-system-phone-input/',
+    description:
+      'Research, interaction design, and React component work for an international phone input',
+  },
+  {
+    title: 'Klaviyo Ascent Design System documentation site',
+    path: '/portfolio/klaviyo-asecnt-design-system-documentation-site/',
+    description:
+      'Product specification, information architecture, and documentation strategy',
+  },
+  {
+    title: 'Simpson Strong-Tie STUDS Design System',
+    path: '/portfolio/design-system-lead-simpson-strong-tie/',
+    description:
+      'Design-system leadership, team growth, and organizational change',
+  },
+  {
+    title: 'Roll by ADP',
+    path: '/portfolio/roll-by-adp/',
+    description: 'Simplifying mobile payroll for small-business owners',
+  },
+  {
+    title: 'Builders Trust Capital',
+    path: '/portfolio/btc/',
+    description:
+      'Brand strategy, identity, and website design for a hard-money lender',
+  },
+  {
+    title: 'Loumarc Signs',
+    path: '/portfolio/loumarc-signs/',
+    description: 'Brand transformation, logo, website, and brand guidelines',
+  },
+]
+
+const OPTIONAL_LINKS: CuratedLink[] = [
+  {
+    title: 'Uses',
+    path: '/uses/',
+    description: 'Hardware and software Frank uses',
+  },
+  {
+    title: 'Accessibility statement',
+    path: '/accessibility-statement/',
+    description: 'Accessibility goals, standards, and contact information',
+  },
+  {
+    title: 'Archives',
+    path: '/archives/',
+    description: 'Earlier versions of the site',
+  },
+]
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function escapeLinkLabel(value: string): string {
+  return normalizeText(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+}
+
+function formatLink(site: URL, link: CuratedLink): string {
+  const url = new URL(link.path, site)
+  return `- [${escapeLinkLabel(link.title)}](${url.href}): ${normalizeText(link.description)}`
+}
+
+function formatSection(
+  heading: string,
+  links: CuratedLink[],
+  site: URL,
+): string[] {
+  return [`## ${heading}`, '', ...links.map((link) => formatLink(site, link))]
+}
+
+function selectRecentPosts(posts: ReadonlyArray<LlmsPost>): LlmsPost[] {
+  return [...posts]
+    .filter((post) => !post.data.isDraft)
+    .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf())
+    .slice(0, RECENT_POST_LIMIT)
+}
+
+export function buildLlmsTxt(
+  posts: ReadonlyArray<LlmsPost>,
+  site: URL,
+): string {
+  const recentPostLinks = selectRecentPosts(posts).map((post) => ({
+    title: post.data.title,
+    path: `/blog/${post.id}/`,
+    description: post.data.description,
+  }))
+
+  return [
+    '# Frank Stallone',
+    '',
+    '> Designer, developer, and mentor sharing 25 years of experience working on the web.',
+    '',
+    'Frank bridges design and development across SaaS products, design systems, marketing, accessibility, and web craft. Portfolio case studies describe selected client and product work; blog posts reflect Frank’s own perspective and experience.',
+    '',
+    ...formatSection('Start here', START_HERE_LINKS, site),
+    '',
+    ...formatSection('Selected case studies', CASE_STUDY_LINKS, site),
+    '',
+    ...formatSection('Recent writing', recentPostLinks, site),
+    '',
+    ...formatSection('Optional', OPTIONAL_LINKS, site),
+    '',
+  ].join('\n')
+}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,20 @@
+import type { APIRoute } from 'astro'
+import { getCollection } from 'astro:content'
+
+import { buildLlmsTxt } from '../lib/llms-txt'
+
+export const prerender = true
+
+export const GET: APIRoute = async ({ site }) => {
+  if (!site) {
+    throw new Error('The Astro site URL is required to generate llms.txt')
+  }
+
+  const posts = await getCollection('blog')
+
+  return new Response(buildLlmsTxt(posts, site), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}


### PR DESCRIPTION
## Summary

The site now gives LLMs and agents a concise, inference-time guide at `/llms.txt`, making Frank's primary work and writing discoverable without crawling the entire site. The guide deliberately curates the strongest entry points and case studies, while automatically including the six newest published posts.

This uses a native prerendered Astro endpoint instead of a community HTML-to-Markdown integration. That keeps the feature dependency-free, available during development and builds, and avoids maintaining exclusions for sandbox, workshop, archive, and other pages that do not belong in the site's editorial overview.

## Validation

- `npm run test:run` — 19 tests passed
- `npm run build` — completed with zero Astro diagnostics and emitted `dist/llms.txt`
- Confirmed the generated file contains the required heading, summary, curated sections, absolute canonical URLs, and only the six newest non-draft posts
- Served the production artifact locally and confirmed `GET /llms.txt` returns `200` with `text/plain`

## Post-Deploy Monitoring & Validation

- Owner: Frank
- Window: first production deployment after merge
- Healthy signal: `GET /llms.txt` returns `200`, `Content-Type: text/plain`, and begins with `# Frank Stallone`
- Validate that the recent-writing section contains the newest published post and that its linked route returns `200`
- Failure signal: missing route, HTML/error content, draft content, or broken curated links
- Mitigation: revert this PR if the generated endpoint fails or exposes unintended content

## New concepts

### `llms.txt` as a curated orientation file

`llms.txt` is a proposed root-level Markdown resource that helps an LLM understand a site's purpose and choose which pages to read at inference time. It complements a sitemap and `robots.txt`: the sitemap is exhaustive discovery, `robots.txt` communicates crawler policy, and `llms.txt` supplies editorial context.

| Approach | Best for | Tradeoff |
|---|---|---|
| Curated Astro endpoint | A personal site where identity, selected work, and current writing matter most | Important links are intentionally maintained in code |
| Post-build HTML scraping | Documentation sites that need Markdown mirrors of most pages | Adds conversion dependencies and requires page/selector exclusions |

This PR uses the curated approach because the valuable output is a small guide, not a second copy of every page. It would be the wrong choice if the goal later expands to `llms-full.txt` or per-page Markdown mirrors; at that point a maintained conversion integration becomes worth reconsidering.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
