### PR TITLE
docs: ground taste and craft articles in product work

### DIFF
--- a/src/content/blog/craft-is-time-on-stone.mdx
+++ b/src/content/blog/craft-is-time-on-stone.mdx
@@ -6,13 +6,13 @@ publishDate: 05-18-2026
 description: 'AI can rough out product work quickly, but craft is the discipline of shaping the real thing until only what matters remains.'
 ---
 
-In the first post in this series, I wrote that [taste is trained judgment](/blog/taste-is-trained-judgment/). Taste helps us see what is good, what is weak, what is generic, what is overworked, and what is missing. It gives us a way to judge the work without getting trapped in personal preference.
+In the first post in this series, I wrote that [taste is trained judgment](/blog/taste-is-trained-judgment/). Taste helps us see the gap between something that works and something that is good.
 
-But taste isn't enough. You can see the problem clearly and still not do the hard part.
+Craft is what happens when we stay with that gap.
 
-You can know the interface is too loud, the hierarchy is off, the action is buried, the component feels unfamiliar, or the AI generated version feels like generic SaaS. Craft is what happens after you see it. It's the discipline of staying with the work long enough to make it right.
+An engineer-led project recently came to me after AI had helped take a workflow from zero to one. Every step, from creating the workflow to viewing it, lived on a single route. You could complete the job, and the team had a working demo.
 
-That sounds obvious, but seeing is a discipline of its own. Most of us are trained to recognize a screen and move on: it renders, the button clicks, the ticket says done. Craft starts when we stay with it long enough to notice the quieter things: where the eye hesitates, where the expectation breaks, where the tone shifts, and where the product asks decoration to do the work of structure. You cannot shape what you have not actually seen.
+Functionally, it was all there.
 
 <RailDigression label="Digression 01">
   <Fragment slot="note">
@@ -24,53 +24,66 @@ That sounds obvious, but seeing is a discipline of its own. Most of us are train
   than it actually is.
 </RailDigression>
 
-That is the danger. AI makes the rough shape cheap, but it does not remove the need for craft. If anything, it makes craft more visible because the distance between "this exists" and "this is good" is now where most of the value lives.
+Then I used it in a browser window.
 
-## We are in a Loos moment
+The creation flow, long forms, and final view were all competing for the same space. Major forms lived inside dialogs. The main view asked someone to hold so much information at once that understanding what mattered became work of its own.
 
-In 1908, the Austrian architect Adolf Loos wrote an essay called _Ornament and Crime_. The idea underneath it is simple: decoration for its own sake obscures the thing it is attached to. If the ornament does not serve the object, remove it.
+The workflow worked, but it wasn't resolved.
 
-Dieter Rams later said it as ["less, but better"](https://www.vitsoe.com/us/about/good-design). His tenth principle expands the idea:
+I moved the large creation form onto its own focused route and gave it a proper flow. I added the labels the fields needed. I removed illustrative and decorative icons that weren't helping anyone understand the interface. Some actions that had been presented as manual steps became automatic because the product already knew enough to do the work.
 
-> Good design is as little design as possible.
-
-The through line is restraint. **Restraint is care under pressure**. It's the ability to look at something that could have more and decide it shouldn't. That feels extremely relevant right now because AI is _very_ good at more.
-
-More cards, more badges, more counting, more icons, more gradients, more shadow, more helper text. More custom components when a better battle-hardened version already exists in the blessed component library. This is ornament, just in React and Tailwind.
-
-The question Loos was asking in 1908 is still the question. Do we add more, or do we strip the thing back until what matters can be seen?
+None of that changed the fundamental capability. It changed how clearly someone could use it.
 
 ## Craft isn't polish
 
-Polish is often how we talk about craft when we're in a hurry. "This needs polish" usually means the thing feels unfinished or unresolved. The spacing is probably off, states might be missing, the interaction may be a little clumsy, or the copy might be doing that generated thing where it sounds helpful but says nothing.
+Polish makes it sound like the workflow was already shaped and I came along to make it nicer. That isn't what happened.
 
-But polish can sound like shine, like the thing is already shaped and now someone should make it nicer. Craft asks a deeper question: is the thing shaped correctly in the first place?
+Moving the form changed the information architecture. Adding labels changed whether someone could understand and navigate it. Automating unnecessary actions changed the workflow itself. Removing decoration gave the important information room to do its job.
+
+Those are product decisions, not finishing touches.
+
+This is the distinction I care about when I say something needs craft. The question isn't whether the spacing could be tighter or the interface could feel more designed. The question is whether the thing is shaped correctly in the first place.
 
 - Does the hierarchy match the decision the user is trying to make?
-- Does the component already exist in the design system?
-- Does the color communicate intent, or is it just making the screen less boring?
-- Does the motion clarify cause and effect?
-- Does the empty state help someone move forward?
-- Does the interface still work with real data, long labels, failures, loading states, and awkward edge cases?
+- Does this step need to exist, or can the product do the work?
+- Does the interface still hold together with real data, long labels, failures, loading states, and awkward edge cases?
 - If we remove this element, what actually gets worse?
 
-Those are not polish questions. They are craft questions.
+Craft begins with something concrete enough to inspect and change. A working implementation gives us that material. It doesn't mean the work is over. It means we can finally see the work.
 
-## The lens comes from brand
+## Subtraction is harder than addition
 
-But craft also needs a point of view. The industry standard gets you to competent, but we can do better. A product can meet the baseline and still feel like it could belong to anyone.
+The Austrian architect Adolf Loos wrote an essay called [_Ornament and Crime_](https://depts.washington.edu/vienna/documents/Loos/Loos_Ornament.htm). His argument about ornament was more complicated than the shorthand we remember, but the question underneath it still matters: does the decoration serve the thing it is attached to?
 
-That is where brand becomes useful. Not brand as the logo mark in the corner or the brand color, but brand as a set of quality filters. If the brand guide says the product should feel calm, precise, expert, or direct, those words shape hierarchy, density, motion, copy, color, empty states, and the way the product asks someone to make a decision.
+Dieter Rams later gave designers a cleaner version: ["less, but better"](https://www.vitsoe.com/us/about/good-design). His tenth principle expands the idea:
 
-A good quality lens turns "this doesn't feel right" into something the team can use. "This is clear, but it's not calm." "This is efficient, but it's not generous." "This is visually interesting, but it's not trustworthy." The point is to give craft a direction, so subtraction does not become blandness and polish does not become decoration.
+> Good design is as little design as possible.
 
-## The rough-out is the start
+The through line is restraint. **Restraint is care under pressure.** It's the ability to look at something that could have more and decide it shouldn't.
 
-One way I have been thinking about AI generated product work is as a rough-out. In sculpture, the rough-out is the early stage where the broad form starts to emerge.
+More cards, more badges, more counting, more icons, more gradients, more shadow, more helper text. More custom components when a better battle-hardened version already exists in the blessed component library. This is ornament, just in React and Tailwind.
 
-You can see the shape. You can see where it's going. But nobody mistakes that for the finished work.
+AI is very good at more. Adding gives us something visible to point at, which can feel like progress. Subtraction is harder because it forces us to decide what the product is really trying to help someone do.
 
-In software, AI is getting very good at rough-outs. It can create the route, wire the form, sketch the layout, stub the interaction, generate the component, and make something you can click through. That is useful because it gets us to the material faster. The rough-out is what lets the work begin.
+In the workflow, removing decorative icons was the easy part. The harder subtraction was recognizing that creation didn't belong beside every other step, and that some of the manual actions didn't need to exist at all.
+
+That kind of subtraction isn't about making an interface sparse. It's about removing competition, ceremony, and work until the important thing has enough room to be understood.
+
+The useful question isn't simply, "Can we remove this?" It is, "What gets worse if we do?" If the answer is nothing, the element probably hasn't earned its place.
+
+Subtraction still needs judgment. Remove things indiscriminately and the result isn't clear. It's just empty.
+
+Taste gives restraint a direction. It helps us decide what matters enough to remain. Craft is how we protect that thing while working through the constraints of the real product.
+
+## We're all working on the same block
+
+The metaphor I keep coming back to is a Renaissance sculpture studio. In some studios, the master made a wax model and specialists carved the marble to match it. The design was fixed. The execution followed.
+
+That isn't how modern product work feels to me, especially with AI in the loop. There usually is no perfect model that contains every behavior, state, edge case, and interaction detail. There's the thing itself, partly formed, being shaped by people with different specialties.
+
+I think of an engineer-led implementation as a rough-out. It establishes the broad shape, proves the technical path, and gives us something real to use. AI helps us get to that material faster.
+
+You can see the shape. You can see where it's going. But nobody mistakes a rough-out for the finished work.
 
 <RailDigression label="Digression 02">
   <Fragment slot="note">
@@ -83,39 +96,34 @@ In software, AI is getting very good at rough-outs. It can create the route, wir
   different parts of the work.
 </RailDigression>
 
-The AI rough-out can make both sides feel closer than they are. It can satisfy the ticket while still missing the product. It can compile while still feeling generic. It can look polished while still being wrong. Craft is the part where we refuse to let "it exists" become the same thing as "it's done."
+Both reactions make sense because the rough-out makes different kinds of work visible. It can satisfy the ticket while still missing the product. Craft is the part where we refuse to let "it exists" become the same thing as "it's done."
 
-## Time on stone
+I don't use Figma for this work. I work in the codebase itself. The engineers rough in the functionality, then I take out the finer tools and work through the hierarchy, interaction, accessibility, and details that make the workflow feel resolved.
 
-The metaphor I keep coming back to is a Renaissance sculpture studio. In some studios, the master made a wax model and specialists carved the marble to match it. The design was fixed. The execution followed.
+We're all standing around the same block of marble. The craft happens during time on stone.
 
-That isn't how modern product work feels to me, especially with AI in the loop. There usually is no perfect wax model. There's no static artifact that contains every behavior, state, edge case, and interaction detail. There's the thing itself, partly formed, being shaped by people with different specialties.
+Time on stone is when we shape the real material together, inside the product and its constraints. This is where the rough-out becomes a product experience.
 
-Software engineers, AI engineers, product designers, design engineers, and product managers are all standing around the same block of marble. The craft happens during time on stone.
+The component structure gets simpler. The spacing stops being arbitrary. The action moves to where the user expects it. The scary state gets clearer. The generated copy gets deleted. The empty state stops trying to be charming and starts being useful.
 
-Time on stone is when we shape the real material together. Not just the Figma file, the pull request, or the Storybook component in isolation. The actual product, in the actual system, with actual constraints. This is where the rough-out becomes a product experience.
+Small things, but not shallow things. Product quality rarely falls apart all at once. It drifts one decision at a time.
 
-The component structure gets simpler. The spacing stops being arbitrary. The action moves to where the user expects it. The scary state gets clearer. The generated copy gets deleted. The custom color becomes a semantic token. The one-off component becomes the canonical component. The empty state stops trying to be charming and starts being useful.
+That is the part of craft I think AI makes more important, not less. When output gets faster, someone still has to stay with the material long enough to ask: what is this becoming?
 
-Small things, but not shallow things. That is the part of craft I think AI makes more important, not less. When output gets faster, the product needs more people who can spend focused time on the actual material and ask: what is this becoming?
+## Review is part of the craft
 
-This is why the small things matter. Product quality rarely falls apart all at once. It drifts. One screen gets a custom gray, another gets a slightly different card treatment, one workflow puts the primary action in the footer, and another puts it in the header. Nobody makes a catastrophic decision. The product just slowly becomes less itself.
+When an engineer-led rough-out reaches me, I don't start by changing the frontend. I read the engineer's architectural design documents first.
 
-## A small exercise
+I need to understand why the feature was built that way, which constraints are real, and what I might be missing. If something isn't clear, I ask the engineer before I start moving things around. I also reach out to stakeholders who actually use the workflow when I need to clarify my thinking along the way. That isn't ceremony. It keeps me from resolving the wrong problem.
 
-Pick one AI generated screen, prototype, or pull request. Don't ask whether it works. Assume it works. Now spend ten minutes looking at it as material.
+Then I work on the frontend design myself, in the codebase.
 
-- What was added because the tool could add it?
-- What is decorative but not useful?
-- What is custom but should be canonical?
-- What feels generic instead of specific to the product?
-- Where does the interface create hesitation?
-- Where does the hierarchy fail under real data?
-- What would you remove first?
-- What needs time on stone?
+Review can sound like someone arrives at the end to approve or reject the work. This is closer to joining the work once the material is concrete enough to react to. The architecture, functionality, and interface are different parts of the same product. Changing one can reveal something about the others.
 
-AI gives us speed, and that speed is useful. The opportunity is to use some of that time to step back, look at what we made, and make it better.
+The workflow at the beginning of this post still did the same fundamental job after I worked through it. It just stopped asking the user to carry the shape of the implementation in their head.
 
-That fits the moment, and the way I see product teams on the leading edge increasingly work. Getting to something real quickly matters, but speed only helps if we use it with judgment.
+That is what time on stone is for.
 
-Taste lets us see. Craft makes us stay. Leverage is how we make that judgment easier for everyone else to use.
+Craft is not decoration. Craft is the visible result of decisions made carefully enough to disappear.
+
+Taste helps us see what matters. Craft helps us remove what does not.

--- a/src/content/blog/taste-is-trained-judgment.mdx
+++ b/src/content/blog/taste-is-trained-judgment.mdx
@@ -6,32 +6,37 @@ publishDate: 04-26-2026
 description: 'AI can generate polished screens quickly, but taste is the trained judgment that helps us see what is actually good.'
 ---
 
-Lately, when I'm building apps with AI in the loop, I keep seeing the same thing. AI can generate screens that *look* finished.
+At [TENEX](https://tenex.ai/), we're building an AI-native, human-led security platform that triages alerts, investigates threats, and helps security teams respond. Lately, I've been using AI to help build the product, and I've been surprised by how quickly it can create something that looks finished.
 
-That sentence still feels strange to write, but it's true. You can ask a model to create a dashboard, a settings page, a workflow, a form, or a dozen versions of the same product screen. In seconds, you get something that compiles, renders, has hover states, and looks close enough.
+I saw this while working on an investigation workflow. It worked. An analyst could complete the job, and at first glance, the workflow looked done.
 
 <RailDigression label="Digression 01">
-<Fragment slot="note">
-At this point in time I'm jealous at how fast software engineers can create functionality.
-</Fragment>
-For a minute, it can feel like real progress.
+  <Fragment slot="note">
+    At this point in time I'm jealous of how fast software engineers can create
+    functionality.
+  </Fragment>
+  For a minute, it can feel like real progress.
 </RailDigression>
-But polished looking is not the same as good. When software engineering gets cheap, the hard part becomes deciding what deserves to ship.
 
-I think that's why taste has become such a loud topic again. Some people are calling [taste a new core skill for the AI era](https://www.axios.com/2026/04/19/ai-taste-anthropic-claude-opus). Others are pointing out that [taste has always been part of the work](https://www.vitsoe.com/us/about/good-design). I think both sides are right.
+Then I looked closer.
 
-Taste is newly visible because AI made software engineering cheap. But taste itself is not new. It has always been the difference between something that merely works and something that feels right.
+There were icons that didn't explain anything, form fields without labels, and patterns that didn't match the rest of the product. A major form lived inside a dialog, where pressing Escape or clicking outside could cause someone to lose their work.
 
-I don't know that I ever thought taste was innate, but I also don't think I understood how much it could be cultivated. The more product and logo work I've done, and the more AI generated work I've reviewed, the more obvious that feels.
+None of those problems necessarily stopped the workflow from functioning. Together, they were the difference between something that worked and something I'd consider good.
 
-The mistake is treating taste like a mystical trait. Like some people are born with good taste and everyone else is out of luck.
+Our CEO, Eric Foster, says it plainly: [AI handles the volume. Humans handle the judgment.](https://tenex.ai/blog/series-b-blog/) I've found that the same idea applies when we're building the product itself.
+
+That gap is probably why we're talking about taste again. Some people are calling [taste a new core skill for the AI era](https://www.axios.com/2026/04/19/ai-taste-anthropic-claude-opus). Designers have been working with the same idea for much longer. Both can be true: AI didn't create the need for taste. It made the need harder to ignore.
+
+I don't know that I ever thought taste was innate, but I didn't understand how much it could be developed. The more product and logo work I've done, and the more AI-generated work I've reviewed, the clearer that has become.
+
+The mistake is treating taste like a mystical trait—like some people are born with it and everyone else is out of luck.
 
 <RailDigression label="Digression 02">
-<Fragment slot="note">
-It wouldn't surprise me if, in six months, AI developed better taste.
-</Fragment>
-I don't buy that. Taste is trained judgment.
+  <Fragment slot="note">Taste may be the last moat.</Fragment>I don't buy that
+  taste is mystical. Taste is trained judgment.
 </RailDigression>
+
 ## Taste is not preference
 
 Preference is personal. Taste is judgment.
@@ -46,41 +51,37 @@ Taste says:
 
 > This card layout works because the hierarchy matches the user's decision path. The most important information is scannable first, the secondary details are available without competing, and the action is placed where the user naturally expects to act.
 
-Preference says:
-
-> I like this logo mark.
-
-Taste says:
-
-> This logo mark works because it identifies the organization without trying to communicate everything the organization does. It is appropriate, distinctive, and simple enough to work on a sign, an app icon, or a pin. It gives the brand something recognizable to build from.
-
-That's a different level of conversation.
+Logo work works the same way. "I like this mark" doesn't tell us whether it identifies the organization without trying to communicate everything the organization does. It doesn't tell us whether the mark is appropriate, distinctive, or simple enough to work on a sign, an app icon, or a pin. Those are reasons a team can examine and use.
 
 "I like it" doesn't scale. Teams and organizations can scale reasoning, shared language, and principles. But if taste stays trapped inside personal preference, every design conversation becomes a debate over vibes.
 
-That's where design conversations get stuck. "Can we make this pop?" "It feels too flat." "Can we add more color?" None of those comments are wrong, exactly. They are just incomplete. The better question is: what problem are we trying to solve?
+That's where design conversations get stuck. "Can we make this pop?" "It feels too flat." "Can we add more color?" None of those reactions are wrong, exactly. They're just incomplete.
 
-Are we trying to create emphasis? Reduce hesitation? Make the next action clearer? Increase trust? Make the interface feel more precise? Are we trying to make the logo mark more iconic, reduce how much it is trying to say, or turn a literal picture into a simpler symbol people can associate with the organization?
+When someone asks to make something pop, I want to know what problem they're actually seeing. Is the next action too easy to miss? Is the hierarchy causing hesitation? Those are problems we can work on. More color might be the answer, but now we have a reason for using it.
+
+Logo critiques need the same move. Is the mark hard to recognize, or is it trying to communicate too much? "Make it more iconic" isn't useful direction until we can explain what's getting in the way.
 
 That's when taste gets useful. It gives the reaction somewhere to go.
 
-This isn't a new idea. David Hume wrote about taste as something improved through practice and comparison in [_Of the Standard of Taste_](https://sourcebooks.fordham.edu/mod/1760hume-taste.asp). Dieter Rams made it feel more practical for designers with principles like ["good design is as little design as possible"](https://www.vitsoe.com/us/about/good-design).
-
-That is the version of taste I mean here. Not personality. Not instinct alone. Trained judgment formed through exposure, comparison, critique, and repetition.
+David Hume wrote about taste as something improved through practice and comparison in [_Of the Standard of Taste_](https://sourcebooks.fordham.edu/mod/1760hume-taste.asp). That's the version I mean here. Not personality or instinct alone. Judgment built through exposure, comparison, critique, and repetition.
 
 ## Before you can judge, you have to see
 
-The first step in developing taste is not making things. It's seeing things. That sounds obvious, but most of us don't really see what is in front of us (no offense). We glance. We recognize. We categorize. We move on.
+Developing taste starts with learning to see. That sounds obvious, but I still catch myself recognizing what's in front of me without really looking at it. I glance. I categorize. I move on.
 
-This happens constantly when reviewing AI generated product work. A list gets a count it doesn't need. A quiet action gets an icon. A section gets a new color just so it feels different. A dense settings area gets the same breathing room as a simple empty state. An existing component gets extra class names even though the canonical version already looks good without overrides.
+I see the same thing when I'm reviewing AI-generated product work. A list gets a count it doesn't need. A quiet action gets an icon. A section gets a new color just so it feels different. A dense settings area gets the same breathing room as a simple empty state. An existing component gets extra class names even though the canonical version already looks good without overrides.
 
-Technically, the screen renders. The component works. The acceptance criteria are met. The ticket moves forward. But did anyone really look at it?
+Technically, the screen renders. The component works. The acceptance criteria are met. The ticket moves forward. If I'm only checking for completion, that can feel like enough.
 
-Did anyone notice where the eye goes first? Did anyone notice that the count pulls attention away from the list, that the icon doesn't clarify the action, that the spacing works in one section but falls apart when the density changes? That's the gap between functional and crafted.
+But if I keep looking, I start to see where the eye goes first. The count pulls attention away from the list. The icon doesn't clarify the action. The spacing works in one section but falls apart when the density changes.
 
-There's an [old story about Louis Agassiz](https://en.wikipedia.org/wiki/Parable_of_the_Sunfish), a naturalist at Harvard, giving a student a fish and telling him to keep looking at it. The student saw the obvious things first, then ran out of observations. Agassiz kept sending him back. More looking. More comparison. More attention. Eventually the student started noticing what was actually there.
+That's the gap between functional and crafted.
 
-Learning to see means slowing down long enough to notice what the interface is actually doing to the user. Not what we intended it to do. Not what the ticket says it should do. What it's doing.
+Josef Albers [built his color courses around a simple problem: color deceives us](https://www.albersfoundation.org/alberses/teaching/interaction-of-color). His students worked with pieces of colored paper, changing what surrounded them until one color looked like two different colors—or two different colors looked the same.
+
+The point wasn't to memorize the right combinations. It was to see how easily context changes perception, and to get better at noticing what the eye misses on its first pass.
+
+Interfaces work the same way. A color, component, or spacing decision can look fine in isolation and feel completely wrong inside the product around it. Learning to see means slowing down long enough to notice what the interface is actually doing to the user. Not what we intended it to do. Not what the ticket says it should do. What it's doing.
 
 - Where did I hesitate?
 - Where did my expectation break?
@@ -96,10 +97,10 @@ These are taste questions, but they start as observation questions.
 The thing I keep coming back to is this: users don't judge your product only against your competitors. They judge it against every good piece of software they use.
 
 <RailDigression label="Digression 03">
-<Fragment slot="note">
-Although honestly maybe not Apple these days.
-</Fragment>
-Your B2B dashboard is being compared, quietly and subconsciously, to Linear, Notion, Raycast, Stripe, Apple, and whatever else lives in the user's daily software diet.
+  <Fragment slot="note">Although honestly maybe not Apple these days.</Fragment>
+  Your B2B dashboard is being compared, quietly and subconsciously, to Linear,
+  Notion, Raycast, Stripe, Apple, and whatever else lives in the user's daily
+  software diet.
 </RailDigression>
 
 That might feel unfair. It doesn't matter. 😅
@@ -118,37 +119,34 @@ It all looks fine. But fine can hide weak judgment.
 
 I wrote a little about this in [AI is very good at adding. Design is required to subtract.](/blog/ai-is-very-good-at-adding-design-is-required-to-subtract/) The next post in this series is about craft, so I won't go too far down the subtraction path here. For now, I think of taste as the thing that helps you decide whether the polished output deserves to stay.
 
-## Shared language creates shared taste
+## I was the dependency
 
-Taste can't scale if it only lives in one person's head. A senior designer saying, "This doesn't feel right," may be correct. But if the team can't understand the reasoning, the judgment doesn't spread. It creates dependency. Everyone waits for the person with taste to bless the work.
+Andrej Karpathy makes a [useful distinction between vibe coding and agentic engineering](https://www.youtube.com/watch?v=96jN2OCOfLs&t=963s). Vibe coding raises the floor. More people can make working software. Agentic engineering is about preserving the quality bar while moving faster. The agents can produce the code, but the engineer is still responsible for the security, architecture, and whether the thing is any good.
 
-That might work for a little while, but it doesn't scale. What I've found more useful is turning taste into language. A team should be able to point at a screen and ask clear questions:
+I think design is running into the same problem. LLMs can raise the floor, but the average thing they produce is not the premium bar. Designers and engineers develop tacit knowledge from doing the work repeatedly. That knowledge helps us recognize the little things that make something feel unresolved, even when it technically works.
 
-- Is this calm enough for the decision being made?
-- Is this trustworthy enough for the claim it makes?
-- Is this fast enough for the user's context?
-- Is this generous enough for someone seeing it for the first time?
-- Is this focused enough to remove doubt about the next action?
+At the time I gave this presentation, I was the only designer working with six-plus agentic engineers at a young startup. They could create functional features faster than I could review them.
 
-Those words should come from the brand. A bank, a creative tool, a healthcare workflow, a developer platform, and a consumer social app are different brands, so quality should look and feel different in each.
+I was the dependency.
 
-For me, this gets practical when brand strategy turns into a few product quality filters. Not a wall of values. A small set of words that can survive a design review, guide a pull request, shape a scope decision, and constrain an AI generated first pass.
+Honestly, I didn't scale well enough to serve the team. I could look at a workflow and say it hadn't cleared the premium bar, or that the design wasn't resolved yet. I knew what I meant. But too much of the reasoning still lived in my head, so the work had to come through me before that judgment became useful.
 
-If the words can't change the product, they aren't doing enough work. Shared language is how taste moves from one person into the team, and eventually into the organization.
+<RailDigression label="Digression 04">
+  <Fragment slot="note">
+    Agentic design engineering? I coined it. I don't love it. 🤣
+  </Fragment>
+  It's the closest phrase I have for designers holding the same quality bar
+  while working through agents.
+</RailDigression>
 
-## A small exercise
+That was the intention behind the quality filters. Tie product judgment to the brand attributes so the team has language for what is working, what is missing, and what needs more attention.
 
-Pick one screen from a product you use often. Set a timer for ten minutes. Don't redesign it. Don't fix it. Don't jump into solutions. Just write what you notice.
+We don't use that language internally yet. I want to be honest about that. It was the intention, and I still think the idea is right.
 
-- Where does your eye go first?
-- What feels obvious?
-- What feels uncertain?
-- Where would a new user hesitate?
-- What is louder than it needs to be?
-- What is quieter than it should be?
-- What feels intentional?
-- What feels accidental?
+I still use "premium bar" and "resolved" when I'm reviewing work. Those words point at something real, but they're only useful if I can explain what I see and why it matters.
 
-Do this regularly and your eye will sharpen. Do it with your team and your language will sharpen. That's where better product work starts. Not with a new tool. Not with a more polished mockup. Not with another generated variation. Just attention, practiced over time.
+That's the part I didn't do well enough. I could see the gap, but I hadn't given the team enough language to see it with me.
 
-The more clearly you see, the more clearly you can decide.
+The point isn't to turn taste into a checklist. It's to make the judgment useful before everything has to come through one person.
+
+The more clearly we see, the more clearly we can decide.


### PR DESCRIPTION
## Summary

The first two posts in the taste, craft, and leverage series now earn their arguments through firsthand product work instead of abstract design advice. Taste is grounded in trained judgment and the cost of becoming a team bottleneck; craft follows an engineer-led workflow from a functional rough-out through stakeholder-informed refinement in the codebase, while preserving leverage as the subject of part three.

## Validation

- `npm run build` — Astro check completed with 0 errors, warnings, or hints, and the production build succeeded.
- Prettier and `git diff --check` passed for both article revisions.
