### PR TITLE
fix: give article illustrations room to breathe

### DIFF
--- a/src/components/mdx/CraftWorkflowIllustration.astro
+++ b/src/components/mdx/CraftWorkflowIllustration.astro
@@ -3,7 +3,7 @@ import { CraftWorkflowIllustration as InteractiveCraftWorkflow } from '@componen
 ---
 
 <figure
-  class="post__popout flow"
+  class="post__popout flow mt-l mb-s"
   aria-label="Interactive rough-out and resolved workflow comparison"
 >
   <InteractiveCraftWorkflow client:visible />

--- a/src/components/mdx/LeverageTasteIllustration.astro
+++ b/src/components/mdx/LeverageTasteIllustration.astro
@@ -3,7 +3,7 @@ import { LeverageTasteIllustration as InteractiveLeverageTaste } from '@componen
 ---
 
 <figure
-  class="post__popout flow"
+  class="post__popout flow mt-l mb-s"
   aria-label="Interactive repeated feedback and encoded judgment comparison"
 >
   <InteractiveLeverageTaste client:visible />

--- a/src/components/mdx/TasteJudgmentIllustration.astro
+++ b/src/components/mdx/TasteJudgmentIllustration.astro
@@ -3,7 +3,7 @@ import { TasteJudgmentIllustration as InteractiveTasteJudgment } from '@componen
 ---
 
 <figure
-  class="post__popout flow"
+  class="post__popout flow mt-l mb-s"
   aria-label="Interactive preference and judgment comparison"
 >
   <InteractiveTasteJudgment client:visible />


### PR DESCRIPTION
## Summary

The interactive illustrations in all three series posts now have a deliberate, balanced pause from the surrounding copy. The spacing stays visually equal by pairing a larger gap above each figure with a smaller gap below that combines with the following paragraph's normal rhythm.

## Validation

- `npm test -- --run` — 19 tests passed.
- `npm run build` — Astro check and production build passed with zero diagnostics.
- Reviewed all three illustrations locally at desktop and mobile widths.
