### PR TITLE
docs: sharpen portfolio case studies

### DIFF
--- a/src/components/ADSBanner.astro
+++ b/src/components/ADSBanner.astro
@@ -6,7 +6,7 @@
   <hgroup>
     <h3 class="mt-zero">
       <a href="/portfolio/klaviyo-asecnt-design-system-documentation-site/"
-        >Ascent Documentation Site</a
+        >Ascent documentation site</a
       >
     </h3>
     <p class="text-step-00 text-gray-1100 mt-zero">

--- a/src/components/ADSBanner.astro
+++ b/src/components/ADSBanner.astro
@@ -10,11 +10,12 @@
       >
     </h3>
     <p class="text-step-00 text-gray-1100 mt-zero">
-      Design systems, cross-team collaboration, process
+      Design systems, product strategy, team process
     </p>
   </hgroup>
   <p class="text-step-00 text-gray-1200">
-    Creating a design system documentation site for Klaviyo, a marketing
-    automation platform, collaboration exploration.
+    I planned a public documentation site for Klaviyo's Ascent Design System,
+    replacing scattered Confluence and Google Docs with a clearer home for
+    components, guidance, and team decisions.
   </p>
 </div>

--- a/src/components/ADSPhoneBanner.astro
+++ b/src/components/ADSPhoneBanner.astro
@@ -10,7 +10,7 @@ const { variant = 'default' } = Astro.props as Props
   <hgroup>
     <h3 class="mt-zero">
       <a href="/portfolio/klaviyo-asecnt-design-system-phone-input/">
-        Phone Input
+        Phone Number Input
       </a>
     </h3>
     <p class="text-step-00 text-gray-1100 mt-zero">
@@ -18,8 +18,8 @@ const { variant = 'default' } = Astro.props as Props
     </p>
   </hgroup>
   <p class="text-step-00 text-gray-1200">
-    I designed a phone input for Klaviyo's Ascent Design System from the ground
-    up. The work brought product, engineering, content, accessibility, and
-    marketing teams around one component.
+    I designed a phone number input for Klaviyo's Ascent Design System from the
+    ground up. The work brought product, engineering, content, accessibility,
+    and marketing teams around one component.
   </p>
 </div>

--- a/src/components/ADSPhoneBanner.astro
+++ b/src/components/ADSPhoneBanner.astro
@@ -10,7 +10,7 @@ const { variant = 'default' } = Astro.props as Props
   <hgroup>
     <h3 class="mt-zero">
       <a href="/portfolio/klaviyo-asecnt-design-system-phone-input/">
-        Phone Number Input
+        Phone number input
       </a>
     </h3>
     <p class="text-step-00 text-gray-1100 mt-zero">

--- a/src/components/ADSPhoneBanner.astro
+++ b/src/components/ADSPhoneBanner.astro
@@ -10,16 +10,16 @@ const { variant = 'default' } = Astro.props as Props
   <hgroup>
     <h3 class="mt-zero">
       <a href="/portfolio/klaviyo-asecnt-design-system-phone-input/">
-        Phone input
+        Phone Input
       </a>
     </h3>
     <p class="text-step-00 text-gray-1100 mt-zero">
-      Design systems, Product design, UX, UI,
+      Design systems, product design, UX, UI
     </p>
   </hgroup>
   <p class="text-step-00 text-gray-1200">
-    A look into the depths of a Phone input for Klaviyo's Ascent Design System.
-    I produced the component from 0 to 1 ensuring multiple team stakeholders
-    were in alignment.
+    I designed a phone input for Klaviyo's Ascent Design System from the ground
+    up. The work brought product, engineering, content, accessibility, and
+    marketing teams around one component.
   </p>
 </div>

--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -27,10 +27,9 @@ const { variant = 'default', sectionIndex = '02' } = Astro.props as Props
           I'm a husband, father, designer, developer, and hopeless optimist.
         </h3>
         <p class="text-step-00 text-gray-1200">
-          Throughout my career, I've bridged the gap between design and
-          development, as well as between marketing and SaaS products, to
-          produce stellar user experiences. I enjoy mentoring and have worked in
-          lab environments at small and large organizations.
+          I work where design and development meet, across marketing and SaaS
+          products. I also enjoy mentoring people and have worked in innovation
+          labs at both small and large organizations.
         </p>
       </div>
       <div

--- a/src/components/BTCPortfolioGrid.astro
+++ b/src/components/BTCPortfolioGrid.astro
@@ -7,7 +7,7 @@ import btcSquared04 from '@assets/squared/btc-squared-04@2x.png'
 ---
 
 <article
-  class="flex flex-col gap-l md:grid"
+  class="flex flex-col gap-l md:grid md:grid-cols-7"
   style="--gutter: var(--spacing-xs);"
   data-layout="sevenths"
 >
@@ -69,12 +69,12 @@ import btcSquared04 from '@assets/squared/btc-squared-04@2x.png'
     src={btcSquared01}
     widths={[500, 700, 1400]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, (max-width: 1600px) 1400px, ${btcSquared01.width}px`}
-    class="object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4 "
+    class="object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4 ',
     }}
-    alt="Initial sketches of the chosen logo for Builders Trust Capital showing the intentions for the three pilars"
+    alt="Initial sketches of the Builders Trust Capital logo showing its three pillars"
     quality={80}
     formats={['avif', 'webp']}
   />
@@ -83,7 +83,7 @@ import btcSquared04 from '@assets/squared/btc-squared-04@2x.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${btcSquared02.width}px`}
     alt="Screenshot of the home page design for Builders Trust Capital"
-    class="object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2 "
+    class="object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2 ',
@@ -96,7 +96,7 @@ import btcSquared04 from '@assets/squared/btc-squared-04@2x.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${btcSquared03.width}px`}
     alt="Screenshot of the presentation for the new Builders Trust Capital logo in context on a sign and business cards"
-    class="object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2 "
+    class="object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2 ',
@@ -109,7 +109,7 @@ import btcSquared04 from '@assets/squared/btc-squared-04@2x.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${btcSquared04.width}px`}
     alt="Logo presentation of the Builders Trust Capital mark and logo type"
-    class="object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2 "
+    class="object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2 ',

--- a/src/components/LoumarcGrid.astro
+++ b/src/components/LoumarcGrid.astro
@@ -7,7 +7,7 @@ import loumarcSquared04 from '@assets/loumarc/shirt-squared.png'
 ---
 
 <article
-  class="flex flex-col gap-l md:grid"
+  class="flex flex-col gap-l md:grid md:grid-cols-7"
   style="--gutter: var(--spacing-xs);"
   data-layout="sevenths"
 >
@@ -60,12 +60,12 @@ import loumarcSquared04 from '@assets/loumarc/shirt-squared.png'
     src={loumarcSquared01}
     widths={[500, 700, 1400]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, (max-width: 1600px) 1400px,  ${loumarcSquared01.width}px`}
-    class="object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4 "
+    class="object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4 ',
     }}
-    alt="Loumarc Signs Logo mock up without the taglin"
+    alt="Loumarc Signs logo mockup without the tagline"
     quality={80}
     formats={['avif', 'webp']}
   />
@@ -74,7 +74,7 @@ import loumarcSquared04 from '@assets/loumarc/shirt-squared.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${loumarcSquared02.width}px`}
     alt="Screenshot of the Loumarc Signs website home page"
-    class="object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2 "
+    class="object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2 ',
@@ -87,7 +87,7 @@ import loumarcSquared04 from '@assets/loumarc/shirt-squared.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${loumarcSquared03.width}px`}
     alt="Mock up of the Loumarc Signs business cards"
-    class="object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2 "
+    class="object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2 ',
@@ -100,7 +100,7 @@ import loumarcSquared04 from '@assets/loumarc/shirt-squared.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${loumarcSquared04.width}px`}
     alt="Mockup of the logo on the front of a shirt"
-    class="object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2 "
+    class="object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2 ',

--- a/src/components/RollBanner.astro
+++ b/src/components/RollBanner.astro
@@ -12,7 +12,7 @@
     </p>
   </hgroup>
   <p class="text-step-00 text-gray-1200">
-    I designed and built Roll's mobile payroll-run experience for small-business
+    I designed and built Roll's mobile payroll experience for small business
     owners. Customers spent about 30 seconds a week in the app, on average.
   </p>
 </div>

--- a/src/components/RollBanner.astro
+++ b/src/components/RollBanner.astro
@@ -8,12 +8,11 @@
       <a href="/portfolio/roll-by-adp/">Roll</a>
     </h3>
     <p class="text-step-00 text-gray-1100 mt-zero">
-      UX, UI, Product design, Design systems
+      Product design, design systems, React, UX
     </p>
   </hgroup>
   <p class="text-step-00 text-gray-1200">
-    Revamping Roll by ADP, I transformed complex payroll processes into an
-    intuitive mobile experience, focusing on simplifying payroll HCM &amp; HR
-    management for small business owners.
+    I designed and built Roll's mobile payroll-run experience for small-business
+    owners. Customers spent about 30 seconds a week in the app, on average.
   </p>
 </div>

--- a/src/components/RollPortfolioGrid.astro
+++ b/src/components/RollPortfolioGrid.astro
@@ -7,7 +7,7 @@ import rollSquared04 from '@assets/squared/roll-squared-04@2x.png'
 ---
 
 <article
-  class="flex flex-col gap-l md:grid"
+  class="flex flex-col gap-l md:grid md:grid-cols-7"
   style="--gutter: var(--spacing-xs);"
   data-layout="sevenths"
 >
@@ -69,7 +69,7 @@ import rollSquared04 from '@assets/squared/roll-squared-04@2x.png'
     src={rollSquared01}
     widths={[500, 700, 1400]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, (max-width: 1600px) 1400px,  ${rollSquared01.width}px`}
-    class="object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4 "
+    class="object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-2 md:row-span-4 md:col-start-1 md:col-span-4 ',
@@ -83,7 +83,7 @@ import rollSquared04 from '@assets/squared/roll-squared-04@2x.png'
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${rollSquared02.width}px`}
     alt="Screenshot of VSCode showing the design tokens repository for Roll by ADP"
-    class="object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2 "
+    class="object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-3 md:row-span-2 md:col-start-6 md:col-span-2 ',
@@ -95,8 +95,8 @@ import rollSquared04 from '@assets/squared/roll-squared-04@2x.png'
     src={rollSquared03}
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${rollSquared03.width}px`}
-    alt="Screenshot of the payroll run conversation UI showcasing the components design and created for our clients"
-    class="object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2 "
+    alt="Payroll conversation showing the components designed for customers"
+    class="object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-5 md:row-span-2 md:col-start-5 md:col-span-2 ',
@@ -108,8 +108,8 @@ import rollSquared04 from '@assets/squared/roll-squared-04@2x.png'
     src={rollSquared04}
     widths={[500, 700]}
     sizes={`(max-width: 360px) 500px, (max-width: 720px) 700px, ${rollSquared04.width}px`}
-    alt="Screenshots of the mock up in design tool highlighting sections and descripting intention"
-    class="object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2 "
+    alt="Design mockup with notes explaining each section"
+    class="object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2"
     pictureAttributes={{
       class:
         'object-cover h-auto md:row-start-1 md:row-span-2 md:col-start-5 md:col-span-2 ',

--- a/src/pages/portfolio/btc.astro
+++ b/src/pages/portfolio/btc.astro
@@ -12,7 +12,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="Transforming Ashmore Partners into Builders Trust Capital, I realigned the brand with its foundational values of trust, stability, and transparency, better connecting them with their entrepreneurial clientele."
+  subtitle="Ashmore Partners had outgrown its name and identity. I helped turn it into Builders Trust Capital, then built the new brand across print and web."
   meta={{
     title: 'Builders Trust Capital',
     description:
@@ -27,11 +27,17 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:row-start-2 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Who they are</h2>
+          <h2 class="mt-zero">
+            The old brand no longer explained the business
+          </h2>
           <p>
-            Builders Trust Capital, originally Ashmore Partners, is a hard money
-            lender focused on empowering entrepreneurs with financial solutions
-            that are built on trust, stability, and transparency.
+            Ashmore Partners was a hard money lender serving real estate
+            entrepreneurs and investors. The team wanted a brand that made three
+            promises clear: trust, stability, and transparency.
+          </p>
+          <p>
+            That meant more than a new logo. The name, identity, writing,
+            website, and sales materials all had to tell the same story.
           </p>
         </div>
         <Picture
@@ -43,25 +49,30 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               'object-contain h-full w-full row-span-6 md:row-start-1 md:row-span-8 col-span-12 md:col-span-8 md:col-start-6',
           }}
           class={'object-contain h-full w-full row-span-6 md:row-start-1 md:row-span-8 col-span-12 md:col-span-8 md:col-start-6'}
-          alt="Small business owner smiling on a call with a customer"
+          alt="Real estate team reviewing building plans"
           formats={['avif', 'webp']}
           loading="lazy"
         />
       </div>
     </div>
-    <div class="wrapper flex flex-col flow md:grid" data-layout="twelfths">
+    <div
+      class="wrapper flex flex-col flow md:grid md:grid-cols-12"
+      data-layout="twelfths"
+    >
       <div
         class="md:row-span-4 md:col-span-8 md:row-start-4 md:col-start-4 flow case-panel z-10"
       >
-        <h2 class="mt-zero">What I did for them</h2>
+        <h2 class="mt-zero">Make the change complete</h2>
         <p>
-          I spearheaded a comprehensive rebranding initiative, renaming the
-          company, creating a new logo and branding style guide, and developing
+          I led the rebrand from naming through launch. The work included a new
+          name, logo, style guide, custom website, and marketing materials.
+        </p>
+        <p>
+          The goal was simple: help entrepreneurs understand the offer and give
+          investors confidence in the company behind it. I designed and built
           <a href="https://builderstrustcapital.com/" target="_blank"
-            >a custom website</a
-          > and marketing materials. This transformation was aimed at better communicating
-          their values to both entrepreneurs and investors, aligning with their mission
-          to facilitate growth and trust.
+            >the website</a
+          > as the clearest expression of that work.
         </p>
       </div>
       <Picture
@@ -73,7 +84,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
             'object-contain h-full w-full row-start-1 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-3',
         }}
         class={'object-contain h-full w-full row-start-1 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-3'}
-        alt="Small business owner smiling on a call with a customer"
+        alt="Builders Trust Capital logo guide"
         formats={['avif', 'webp']}
         loading="lazy"
       />
@@ -86,52 +97,47 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-1 md:col-start-1 md:col-span-6 flow case-panel"
         >
-          <h2 class="mt-zero">The challenge</h2>
+          <h2 class="mt-zero">The old name did not carry the promise</h2>
           <p>
-            The challenge was to refresh the Ashmore Partners brand to one that
-            deeply resonated with their target audience of entrepreneurs and
-            investors, giving them an identity that showcased their values and
-            stood out in the competitive financial space. My goal was to
-            transform their existing brand into one that clearly conveyed their
-            commitment to their client's success, across all physical and
-            digital touch-points.
+            Ashmore Partners did not tell either audience much about the
+            business or what made it different. The new identity had to work for
+            entrepreneurs seeking capital and investors evaluating the company.
+            It also had to hold together across every physical and digital
+            touchpoint.
           </p>
         </div>
         <div
-          class="row-start-13 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-7 md:col-span-7 flow case-panel"
+          class="row-start-13 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-7 md:col-span-6 flow case-panel"
         >
-          <h2 class="mt-zero">My approach</h2>
+          <h2 class="mt-zero">Name what matters</h2>
           <p>
-            I began with deep dives into the company's ethos through group
-            discovery sessions with the Ashmore Partners team. Knowing the aim
-            was to realign their brand to connect with entrepreneurs and
-            investors, it became clear that we'd need to choose a new name that
-            better-embodied trust, stability, and transparency. Through detailed
-            industry research and collaborative brainstorming, "Builders Trust
-            Capital" was born &mdash; a name that perfectly mirrored its
-            foundational principles.
+            I started with group discovery sessions. We defined what the company
+            believed, what both audiences needed to hear, and which parts of the
+            old identity were getting in the way.
           </p>
           <p>
-            From there, we mapped out a plan to develop a fresh logo, a
-            comprehensive style guide, and plans for all the physical and
-            digital collateral we'd need to bring this new identity to life.
+            Industry research and team brainstorming led to Builders Trust
+            Capital. The name put the audience and the promise together:
+            builders, trust, and capital. From there, I planned the logo, style
+            guide, website, and the physical and digital material needed for the
+            launch.
           </p>
         </div>
       </div>
     </div>
     <div class="region wrapper flow prose">
-      <div class="flex flex-col flow md:grid" data-layout="twelfths">
+      <div
+        class="flex flex-col flow md:grid md:grid-cols-12"
+        data-layout="twelfths"
+      >
         <div
           class="md:row-start-1 md:row-span-3 md:col-start-1 md:col-span-6 flow case-panel z-10"
         >
-          <h2 class="mt-zero">The solution</h2>
+          <h2 class="mt-zero">Build one identity across every touchpoint</h2>
           <p>
-            In creating the new Builders Trust Capital identity, the solution
-            needed to cover a lot of different touch-points. I started by
-            collaborating closely with the team on developing a timeless logo
-            that symbolized the renewed brand identity. This process was about
-            creating a symbol that would stand the test of time across both
-            digital and print mediums.
+            I worked with the team on a logo that expressed the new name and
+            held up in print and on screen. The mark needed to feel established
+            without looking dated.
           </p>
         </div>
         <Picture
@@ -143,31 +149,31 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               'object-contain h-full w-full md:row-start-1 md:row-span-10 md:col-span-7 md:col-start-7',
           }}
           class={'object-contain h-full w-full md:row-start-1 md:row-span-10 md:col-span-7 md:col-start-7'}
-          alt="Small business owner smiling on a call with a customer"
+          alt="Builders Trust Capital color palette"
           formats={['avif', 'webp']}
           loading="lazy"
         />
         <div
           class="md:row-start-5 md:row-span-9 md:col-start-1 md:col-span-6 flow case-panel z-10"
         >
-          <p class="mt-zero">
-            In tandem, our copywriter began crafting a voice that captured the
-            essence of Builders Trust Capital, interviewing clients and
-            associates to ensure our messaging was authentic and engaging. This
-            foundational work then led into the development of a full style
-            guide that detailed our color schemes, typography, and layout
-            principles—blending modern vibrancy with the traditional solidity
-            expected in the financial sector.
+          <h3 class="mt-zero">Give the brand a voice</h3>
+          <p>
+            At the same time, our copywriter interviewed clients and associates.
+            Those conversations shaped the voice and kept the language tied to
+            how people described the business.
           </p>
           <p>
-            The digital transformation was next, grounded by a sharp,
+            I turned the identity into a guide for color, type, logo use, and
+            layout. The system balanced energy with the stability people expect
+            from a lender.
+          </p>
+          <h3>Put it to work online</h3>
+          <p>
             <a href="https://builderstrustcapital.com/" target="_blank"
-              >user-friendly website</a
-            > that was not only accessible but responsive across all devices. From
-            wireframing in the browser to integrating live content for real-time
-            feedback, I meticulously crafted each page to reflect the sophistication
-            and clarity of the new brand. This ensured the site looked exceptional
-            and gave a clean and elegant user experience for entrepreneurs and investors.
+              >I designed and built the website</a
+            > from browser wireframes and live content. The site had to be accessible,
+            responsive, and clear on any device. Working with real copy early let
+            us judge the page structure before polishing the design.
           </p>
         </div>
         <Picture
@@ -179,20 +185,20 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               'object-contain h-full w-full md:row-start-10 md:row-span-10 md:col-span-7 md:col-start-7',
           }}
           class={'object-contain h-full w-full md:row-start-10 md:row-span-10 md:col-span-7 md:col-start-7'}
-          alt="Small business owner smiling on a call with a customer"
+          alt="Builders Trust Capital typography guide"
           formats={['avif', 'webp']}
           loading="lazy"
         />
         <div
-          class="md:row-start-19 md:row-span-4 md:col-start-1 md:col-span-6 flow case-panel z-10"
+          class="md:row-start-14 md:row-span-4 md:col-start-1 md:col-span-6 flow case-panel z-10"
         >
-          <h3 class="mt-zero">The results</h3>
+          <h3 class="mt-zero">A clearer company, not just a new logo</h3>
           <p>
-            Through this significant re-branding project, Builders Trust Capital
-            successfully repositioned itself in the market, establishing a brand
-            that stands out for its elegance, clarity and solidity. This
-            transformation has opened doors to new partnerships, and
-            significantly broadened the company's market reach.
+            The company launched with a new name, logo, brand guide, website,
+            and marketing system. The work helped Builders Trust Capital reach
+            new partners and a wider market. Its public identity now matched the
+            principles it wanted to lead with: trust, stability, and
+            transparency.
           </p>
         </div>
       </div>
@@ -207,7 +213,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
             'object-contain h-full w-full row-start-1 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-3',
         }}
         class={'object-contain h-full w-full row-start-1 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-3'}
-        alt="New logo for Builders Trust Logo that reflects their brand substance, and their ideal customers"
+        alt="Builders Trust Capital logo"
         formats={['avif', 'webp']}
         loading="lazy"
       />

--- a/src/pages/portfolio/design-system-lead-simpson-strong-tie.astro
+++ b/src/pages/portfolio/design-system-lead-simpson-strong-tie.astro
@@ -8,11 +8,11 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="A Strategic Approach to Design System Leadership, Team Growth, and Organizational Transformation."
+  subtitle="I helped relaunch Simpson Strong-Tie's STUDS design system after two failed attempts, then built the team practices needed to keep it moving."
   meta={{
-    title: 'Revitalizing UX at Simpson Strong-Tie: The STUDS Design System',
+    title: 'Relaunching the STUDS design system at Simpson Strong-Tie',
     description:
-      "As a Senior Product Designer at Simpson Strong-Tie, I strategically relaunched and scaled the previously unsuccessful STUDS Design System. By taking direct operational leadership and fostering cross-team collaboration, I streamlined workflows, mentored a growing UX team, and significantly enhanced product consistency. My approach not only solved immediate design and operational challenges but also contributed directly to Simpson Strong-Tie's ambitious UX vision for 2030, positioning UX as a strategic driver of business outcomes.",
+      "How I helped relaunch Simpson Strong-Tie's STUDS design system, improve its operating process, and grow the team around it.",
     canonicalURL: canonicalURL.href,
     image: `/media/portfolio/sst-og-image.png`,
   }}
@@ -23,14 +23,16 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Situation</h2>
+          <h2 class="mt-zero">Two failed launches had changed the problem</h2>
           <p>
-            When I joined Simpson Strong-Tie, the UX organization was facing
-            significant challenges. The existing STUDS Design System had
-            previously failed twice, creating internal skepticism and urgency.
-            There were notable skill gaps within design and development teams,
-            limited end-user and stakeholder engagement, and processes that
-            lacked clarity and collaboration.
+            When I joined Simpson Strong-Tie, STUDS had already failed twice.
+            The teams had good reason to be skeptical. Designers and engineers
+            had uneven design system skills, product teams were not closely
+            involved, and the process around the work was unclear.
+          </p>
+          <p>
+            The job was not just to produce components. We had to rebuild trust
+            in the system and give the people using it a way to shape it.
           </p>
         </div>
         <Picture
@@ -50,94 +52,72 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
     </div>
 
     <div class="wrapper">
-      <div class="flow case-panel mx-auto">
-        <h2 class="mt-zero">Task</h2>
+      <div class="flow case-panel center" style="--measure: 60ch;">
+        <h2 class="mt-zero">Stabilize the system and the team around it</h2>
         <p>
-          My role was to strategically relaunch and stabilize the STUDS Design
-          System, close skill gaps across the teams, and implement operational
-          processes to elevate the UX practice. Additionally, I aimed to foster
-          a culture of continuous learning, collaboration, and strategic
-          alignment to support the company's ambitious 2030 business goals.
+          My role was to relaunch STUDS, close the most important design and
+          development gaps, and make the operating process visible. The work
+          also had to support the company's longer term digital strategy.
         </p>
-        <h3>Action</h3>
+        <p>
+          I started with product teams and stakeholders. I listened for their
+          goals, constraints, and measures of success before setting the
+          strategy and backlog.
+        </p>
+
+        <h3>Make the work easier to follow</h3>
 
         <ul>
           <li>
-            <strong>Stakeholder Engagement & Strategy Alignment</strong>:
-            Conducted comprehensive listening tours with product teams and
-            stakeholders to understand goals, constraints, and success metrics.
-            I developed a design system strategy for STUDS that aligned with
-            Simpson Strong-Tie's digital transformation and modernization
-            initiatives.
+            <strong>Strategy:</strong> I turned the listening sessions into a design
+            system strategy tied to the needs of the product teams and the company's
+            digital work.
           </li>
           <li>
-            <strong>Operational Excellence & DesignOps</strong>: Took
-            operational leadership of STUDS' day-to-day design, development,
-            Agile ceremonies introducing clear communication practices (weekly
-            Loom videos and sprint reviews) to improve team consistency and
-            quality. Contributed to the broader UX organization by creating
-            Standard Operating Procedures (SOPs), collaborated on restructuring
-            weekly design reviews to improve transparency and cross-team
-            alignment.
+            <strong>Operations:</strong> I led day to day design, development, and
+            Agile ceremonies for STUDS. Weekly Loom videos and sprint reviews made
+            progress and decisions easier to see.
           </li>
           <li>
-            <strong>Operational Excellence & DesignOps</strong>: Took
-            operational leadership of STUDS' day-to-day design, development, and
-            Agile ceremonies, introducing clear communication practices such as
-            weekly Loom videos and sprint reviews to enhance team consistency
-            and output quality. Additionally, contributed to the broader UX
-            organization by creating Standard Operating Procedures (SOPs) and
-            collaborating on restructuring weekly design reviews to boost
-            transparency and collaboration, and cross-team alignment.
+            <strong>Shared practice:</strong> I wrote standard operating procedures
+            and helped restructure design reviews so teams could see the work earlier
+            and give useful feedback.
           </li>
           <li>
-            <strong>Technical Leadership & Execution</strong>: Led key technical
-            initiatives, including parallel development of React and Blazor
-            component libraries to ensure cross-platform consistency.
-            Contributed to shaping the Simpson Strong-Tie UX Organization's 2030
-            strategic vision. Transitioned the design system to a more
-            digital-friendly typeface (Helvetica Now) to address usability
-            issues, and implemented a robust design token strategy for improved
-            efficiency in design-to-development workflows.
+            <strong>Technical direction:</strong> I led parallel React and Blazor
+            component work, moved the system to Helvetica Now, and set a design token
+            strategy to keep design and development aligned across platforms.
           </li>
           <li>
-            <strong>Team Mentorship & Growth</strong>: Mentored the design team
-            in systems thinking, accessibility compliance, and visual design
-            excellence, empowering them to independently produce high-quality,
-            user-centered designs. Initiated ongoing UX education initiatives,
-            such as team-wide UX book clubs and training sessions.
+            <strong>Team growth:</strong> I coached designers in systems thinking,
+            accessibility, and visual design. Book clubs and training sessions gave
+            the team a regular place to keep learning.
           </li>
         </ul>
-        <h3>Result</h3>
+
+        <h3>Leave behind a system people could run</h3>
 
         <ul>
           <li>
-            <strong>Successful Relaunch and Adoption</strong>: Relaunched and
-            stabilized the STUDS Design System, achieving widespread internal
-            adoption across multiple product teams.
+            STUDS relaunched and was adopted across multiple product teams.
           </li>
           <li>
-            <strong>Increased Efficiency & Collaboration</strong>: Reduced
-            design-development handoff friction significantly, enhancing overall
-            productivity and accelerating product delivery timelines.
+            Shared components and a clearer process reduced friction between
+            design and development.
           </li>
           <li>
-            <strong>Strategic Impact & Team Influence</strong>: Elevated the UX
-            team's strategic visibility within Simpson Strong-Tie, directly
-            contributing to the 2030 digital solutions strategy aimed at
-            increasing Annual Recurring Revenue by hundreds of millions.
+            Designers became more independent in systems thinking,
+            accessibility, and visual design.
           </li>
           <li>
-            <strong>Team Development & Maturity</strong>: Improved the team's
-            overall design capability and strategic thinking, demonstrated by
-            enhanced quality and independence in their project outcomes.
+            The work gave UX a clearer role in Simpson Strong-Tie's 2030 digital
+            strategy.
           </li>
         </ul>
 
         <p>
-          This approach not only addressed immediate UX challenges but laid a
-          solid foundation for sustained innovation and strategic growth aligned
-          with Simpson Strong-Tie's long-term business vision.
+          The useful result was not a launch. It was a system the organization
+          could keep using and a team better able to run it.
         </p>
       </div>
     </div>

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -28,7 +28,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="Design Systems, Development, Brand"
+  subtitle="Design systems, development, and brand."
   meta={{
     title: 'Portfolio of Frank Stallone',
     description: 'The design and development portfolio of Frank Stallone',
@@ -100,14 +100,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               <a href="/portfolio/loumarc-signs/">Loumarc Signs</a>
             </h3>
             <p class="text-step-00 text-gray-1100 mt-zero">
-              Brand transformation, logo, website
+              Brand strategy, logo, website
             </p>
           </hgroup>
           <p class="text-step-00 text-gray-1200">
-            After 30 years in business, Loumarc Signs needed a complete brand
-            refresh to attract a new generation of custom sign buyers. I
-            produced a new logo, website, and set of brand guidelines that
-            successfully connected them to this fresh new audience.
+            After 30 years in business, Loumarc Signs needed a brand that
+            matched the quality of its work. I led the strategy and created its
+            new logo, website, and brand guide.
           </p>
         </div>
       </div>
@@ -123,13 +122,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               <a href="/portfolio/btc/">Builders Trust Capital</a>
             </h3>
             <p class="text-step-00 text-gray-1100 mt-zero">
-              Brand transformation, logo, name, website
+              Brand strategy, naming, website
             </p>
           </hgroup>
           <p class="text-step-00 text-gray-1200">
-            Rebranded Ashmore Partners to Builders Trust Capital, creating a new
-            logo, website, and brand guidelines to better connect with their
-            entrepreneurial clients.
+            I renamed Ashmore Partners as Builders Trust Capital, then created
+            its logo, brand guide, website, and marketing materials around
+            trust, stability, and transparency.
           </p>
         </div>
       </div>
@@ -142,11 +141,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div class="flow flow-space-xs text-gray-1400">
           <hgroup>
             <h3 class="mt-zero">NJ Stone Supply &amp; Tree Service</h3>
-            <p class="text-step-00 text-gray-1100 mt-zero">Logo</p>
+            <p class="text-step-00 text-gray-1100 mt-zero">
+              Logo, visual identity
+            </p>
           </hgroup>
           <p class="text-step-00 text-gray-1200">
-            Designed a logo mark and type that reflects both Noah's work and his
-            audience's needs.
+            I designed a logo and type system that connects Noah's stone supply
+            and tree service work in one clear identity.
           </p>
         </div>
       </div>
@@ -191,15 +192,14 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <div class="flow">
         <div class="flow flow-space-xs text-gray-1400">
           <hgroup>
-            <h3 class="mt-zero">Brackets podcast</h3>
+            <h3 class="mt-zero">Brackets Podcast</h3>
             <p class="text-step-00 text-gray-1100 mt-zero">
-              Co-host, Logo, Branding
+              Podcast, logo, brand identity
             </p>
           </hgroup>
           <p class="text-step-00 text-gray-1200">
-            Co-created a technology podcast that aired for 5 years, serving as
-            the pulse of tech within ADP. Designed the logo and branding to
-            establish a strong, recognizable identity.
+            I co-created and co-hosted Brackets, an ADP technology podcast that
+            ran for five years. I also designed its logo and brand.
           </p>
         </div>
       </div>
@@ -245,11 +245,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div class="flow flow-space-xs text-gray-1400">
           <hgroup>
             <h3 class="mt-zero">Savani</h3>
-            <p class="text-step-00 text-gray-1100 mt-zero">Logo, Branding</p>
+            <p class="text-step-00 text-gray-1100 mt-zero">
+              Logo, brand identity
+            </p>
           </hgroup>
           <p class="text-step-00 text-gray-1200">
-            Rebranded a niche Volkswagen parts company, creating a new logo and
-            brand identity to better connect with their target audience.
+            I rebranded a niche Volkswagen parts company with a new logo,
+            wordmark, color system, and designs for print and apparel.
           </p>
         </div>
       </div>

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -192,7 +192,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <div class="flow">
         <div class="flow flow-space-xs text-gray-1400">
           <hgroup>
-            <h3 class="mt-zero">Brackets Podcast</h3>
+            <h3 class="mt-zero">Brackets podcast</h3>
             <p class="text-step-00 text-gray-1100 mt-zero">
               Podcast, logo, brand identity
             </p>

--- a/src/pages/portfolio/klaviyo-asecnt-design-system-documentation-site.astro
+++ b/src/pages/portfolio/klaviyo-asecnt-design-system-documentation-site.astro
@@ -9,7 +9,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="Creating a design system documentation site for Klaviyo, a marketing automation platform, collaboration exploration."
+  subtitle="A product spec for turning Klaviyo's scattered design system documentation into one useful home."
   meta={{
     title: 'Klaviyo: Ascent Design System Documentation Site',
     description:
@@ -29,7 +29,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
             class: 'object-contain h-full w-full ',
           }}
           class={'object-contain h-full w-full '}
-          alt="Ascent Design System high fidelity mock up - main landing page"
+          alt="Ascent Design System high fidelity landing page mockup"
           formats={['avif', 'webp']}
           loading="lazy"
         />
@@ -40,17 +40,16 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Product Spec</h2>
+          <h2 class="mt-zero">The Spec Was the Work</h2>
           <p>
-            This is a mock up Product Specification written as an example of the
-            RFC process I used at Klaviyo to collaborate cross-team, aligning on
-            goals, and shape the design system documentation site work.
+            This page explores a public home for Klaviyo's Ascent Design System.
+            The main artifact is a mock product spec based on the RFC process I
+            used at Klaviyo.
           </p>
           <p>
-            This document would be owned and written primarily by me, but with
-            stakeholders ability to add/comment throughout. I would engage with
-            those stakeholders on a weekly basis to ensure alignment, discuss
-            ideas, and refine desired outcomes within the time frame we want.
+            I would own the document and work through it with stakeholders each
+            week. The point was to make the goals, limits, open questions, and
+            tradeoffs clear enough for the team to challenge.
           </p>
         </div>
         <Picture
@@ -62,7 +61,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               'object-contain h-full w-full row-span-6 md:row-start-1 md:row-span-6 col-span-12 md:col-span-8 md:col-start-6 ',
           }}
           class={'object-contain h-full w-full row-span-6 md:row-start-1 md:row-span-6 col-span-12 md:col-span-8 md:col-start-6 '}
-          alt="Small business owner smiling on a call with a customer"
+          alt="A team working together around a table"
           formats={['avif', 'webp']}
           loading="lazy"
         />
@@ -70,465 +69,164 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
     </div>
 
     <div class="region wrapper">
-      <div class="flow case-panel mx-auto">
-        <h2 class="mt-zero">Executive Summary</h2>
+      <div class="flow case-panel center" style="--measure: 60ch;">
+        <h2 class="mt-zero">Start With the Mess</h2>
         <p>
-          The Ascent Design System project aims to create a comprehensive,
-          public documentation site for Klaviyo's design system, replacing the
-          current Confluence-based solution with a dynamic,
-          static-site-generated platform using a headless CMS. This new system
-          will significantly improve content organization, component visibility,
-          and overall user experience while showcasing Klaviyo's design maturity
-          to potential talent and investors. Key features include enhanced
-          search functionality, live code demonstrations, strict access control,
-          SEO optimization, integrated analytics, and seamless integration with
-          existing tools. The project will be implemented in three phases over
-          six months, culminating in a full-featured release that aims to
-          improve internal user satisfaction, increase design system usage in
-          product design R&D, and enhance engagement with the broader design
-          system community.
-        </p>
-        <h2>The Problem Statement / User Stories</h2>
-        <p>
-          <em
-            >Describe in depth the problem. How was it discovered and proposed
-            solution. User stories are good to have here.</em
-          >
+          Ascent already had the parts of a design system: Figma UI kits, a
+          React component library, design tokens built with Style Dictionary,
+          voice and tone guidance, and documentation across Confluence and
+          Google Docs.
         </p>
         <p>
-          The goal of a public custom design system documentation site is
-          multifaceted, addressing both internal and external needs. Internally,
-          we aim to streamline features, enhancements, and communication between
-          product, design, and development teams. Externally, we want to
-          showcase our mature design discipline, serving as a touchpoint for
-          investors and prospective talent.
+          The problem was not a lack of material. It was finding the right
+          material and knowing whether it was current. A design system is
+          incomplete when people cannot answer what exists, why to use it, and
+          how to use it.
         </p>
+
+        <h2>Write Down Who Needs It</h2>
         <p>
-          A comprehensive design system aids in consistency, collaboration,
-          productivity, scalability, and quality across the entire Klaviyo
-          product space. The current system includes Figma library UI kits, a
-          React component library, design tokens with style-dictionary, voice
-          and tone guidelines, and documentation in Confluence. However, without
-          clear, accessible, and well-organized documentation to answer what,
-          why, and how, a design system is incomplete.
+          The site had to serve product owners, designers, content designers,
+          data scientists, engineers, and leadership. A public site could also
+          show prospective teammates how Klaviyo approached design and
+          development.
         </p>
-        <p>
-          Confluence, our current stopgap solution, is not organizing content
-          effectively, has findability issues, and lacks features crucial for
-          serving our diverse audience of product owners, designers, content
-          designers, data scientists, leadership, and developers. We need a
-          solution that addresses the following key problems:
-        </p>
-        <ol>
-          <li>
-            Improved Content Organization and Findability: We require better
-            fuzzy logic search, easier-to-use navigation (main and on-page), and
-            a structure that makes it simple for users to locate the information
-            they need quickly.
-          </li>
-          <li>
-            Enhanced Component Visibility and Access: We need to provide clear
-            visibility of available UI components and their APIs, with live code
-            demonstrations and better code API visibility.
-          </li>
-          <li>
-            Authentication and Access Control: The system must support different
-            levels of authentication for CRUD operations, ensuring that only
-            authorized users can make changes while maintaining appropriate
-            access for various user roles.
-          </li>
-          <li>
-            SEO and Discoverability: To showcase our design maturity and attract
-            talent, we need to ensure our design system documentation is
-            discoverable on the web through proper SEO optimization.
-          </li>
-          <li>
-            Analytics and Feedback Mechanisms: We require integrated analytics
-            and a robust feedback system to continuously improve our
-            documentation based on user behavior and direct input.
-          </li>
-          <li>
-            Integration with Existing Tools: The new system should integrate
-            seamlessly with our existing tools and workflows, including Figma,
-            GitHub, Slack, and Jira, to support efficient collaboration and
-            issue tracking.<a href="#dagger-01">†</a>
-          </li>
-          <li>
-            Scalability and Continuous Improvement: We need a flexible system
-            that can grow with our needs, supporting the continuous addition and
-            refinement of content and features.
-          </li>
-          <li>
-            Branding and User Experience: The documentation site should reflect
-            Klaviyo's brand and demonstrate our commitment to excellent user
-            experience, serving as a testament to our design and development
-            expertise.
-          </li>
-        </ol>
-        <p>
-          By addressing these issues, we aim to create a documentation site that
-          not only serves our internal teams more effectively but also positions
-          Klaviyo as a leader in design and development practices within the
-          marketing tech sector.
-        </p>
-        <h3>User Stories</h3>
+        <p>The primary user stories were direct:</p>
         <ul>
           <li>
-            As a Product Designer, I want to see what UI components are
-            available for me to solve my feature or enhancement problem
+            As a Product Designer, I want to find the components available for
+            the problem I am solving.
           </li>
           <li>
-            As a Software Engineer, I want to see what API's are available for
-            the component I am implementing
+            As a Software Engineer, I want to find the API for the component I
+            am implementing.
           </li>
           <li>
-            As a Product Designer on the market, I want to see that Klaviyo
-            cares about design
+            As a contributor, I want to preview and update documentation without
+            fighting the publishing system.
           </li>
           <li>
-            As a Product Designer, or other authorized user, I want to be able
-            to preview, and update the documentation site with ease
-          </li>
-          <li>
-            As the owner of the documentation site, I want strict access on who
-            can and cannot access, or do CRUD actions on the headless CMS
-          </li>
-          <li>
-            As a distinguished brand in the marketing tech sector, Klaviyo wants
-            to show design maturity gaining confidence in the product with our
-            continuous efforts to improve UX/UI/CX
-          </li>
-          <li>
-            As a talented individual on the market, I want to see that Klaviyo
-            takes design and development seriously when doing my research on
-            whether or not to join the company
-          </li>
-        </ul>
-        <h2>Goals and Non-Goals</h2>
-
-        <p>
-          <em
-            >Bulleted list of explicitly what we are, and aren't doing. Used to
-            avoid scope creep.</em
-          >
-        </p>
-        <h3>Goals</h3>
-        <ul>
-          <li>
-            Create a dynamic SSG site with a headless CMS
-            <ul>
-              <li>
-                Static site for the documentation site that builds on publish
-                webhook from headless CMS.
-              </li>
-              <li>
-                Headless CMS with different levels of authentication for CRUD
-                operations
-              </li>
-            </ul>
-          </li>
-          <li>
-            Include all existing UI kit components, migrating documentation and
-            structure in Google Docs to the documentation site
-          </li>
-          <li>
-            Feedback form for users to provide meaningful feedback on any page
-          </li>
-          <li>
-            Deep linking to Figma library, GitHub, and Storybook for direct
-            access to components
-            <ul>
-              <li>
-                These links will only work for authenticated Figma, Storybook or
-                GitHub users
-              </li>
-            </ul>
-          </li>
-          <li>
-            Ensure proper basic SEO meta and Schema.org tags for findability on
-            the web <a href="#dagger-02">††</a>
-            <ul>
-              <li>Set up Google Analytics</li>
-              <li>Set up Google Search Console</li>
-            </ul>
-          </li>
-          <li>Setting up a Slack and Jira for support, requests, etc.</li>
-        </ul>
-        <h3>Non-goals</h3>
-        <ul>
-          <li>
-            Due do the component library living in the monorepo, and not public
-            <ul>
-              <li>
-                Our initial ship will not include code examples - to be scoped
-                in a feature post launch
-              </li>
-              <li>
-                Our initial ship will not include links to a public component
-                library
-              </li>
-            </ul>
-          </li>
-          <li>
-            Due to the Figma libraries not being public
-            <ul>
-              <li>
-                Our initial ship will not include Figma embed UI components
-              </li>
-            </ul>
-          </li>
-          <li>
-            Not integrating into our monorepo due to the lift required by the
-            backend engineering team
-          </li>
-          <li>Implementing a full commenting system per page</li>
-          <li>
-            Build out every section outlined in the sitemap prior to launch
-            <ul>
-              <li>
-                Once we have 80% of the content, as per decided by the design
-                system team, we'll launch and continue to add post launch
-              </li>
-            </ul>
-          </li>
-          <li>Not doing blog integration</li>
-        </ul>
-        <h2>Key Metrics</h2>
-        <p>
-          <em
-            >What does success and failure look like? What can you track to
-            gauge how things went?</em
-          >
-        </p>
-        <ul>
-          <li>
-            Internal consumers of the documentation site can find what they are
-            looking for with greater ease
-
-            <ul>
-              <li>
-                Quarterly surveys we're already doing gain 10% increase in
-                happiness with the documentation site over the next three
-                quarters
-              </li>
-              <li>
-                An increase in aspects of the design system being referenced
-                when doing team R&D
-              </li>
-            </ul>
-          </li>
-          <li>
-            We have a live presence on Google that we can advertise when hiring
-            designers, and developers
-          </li>
-          <li>Create engagement with the design system communities</li>
-        </ul>
-        <h2>Rollback Criteria</h2>
-
-        <p>
-          <em
-            >Think about when we stop doing this. Is it a trap door decision?</em
-          >
-        </p>
-
-        <ul>
-          <li>
-            This is not a trap door decision
-
-            <ul>
-              <li>
-                In other words, we can go back to using Google Docs and
-                Confluence if this should fail
-              </li>
-            </ul>
-          </li>
-          <li>
-            Technical difficulties with regards to the technology stack should
-            be evaluate for graceful fallbacks
-
-            <ul>
-              <li>
-                For instance if there is an issue with the headless CMS, we use
-                Markdown files in Astro itself which we can later migrate
-              </li>
-            </ul>
-          </li>
-          <li>
-            If we're running into major set backs and it looks to be by out Beta
-            time the GA release will miss it's target, we'll implement an
-            intermediary solution like Knapsack, to move off Confluence and
-            Google Docs
+            As the site owner, I want access controls that define who can view,
+            create, edit, and publish content.
           </li>
         </ul>
 
-        <h2>Timelines</h2>
-
+        <h2>Make the First Release Small Enough</h2>
         <p>
-          <em
-            >When do you expect to have an alpha, beta, or general release? If
-            it's a larger project, what milestones or checkpoints will we be
-            tracking?</em
-          >
+          The proposal called for a static site connected to a headless CMS.
+          Publishing in the CMS would trigger a new build. The first release
+          would bring the existing component guidance into one structure, add
+          search and feedback, and link people to Figma, GitHub, and Storybook
+          when they had access.
         </p>
-        <h3>1 Month (Alpha)</h3>
-
+        <h3>In scope</h3>
         <ul>
-          <li>A repeatable local build environment</li>
-          <li>Git repository on the enterprise GitHub account</li>
-          <li>Live website on host Astro site with minimal theming</li>
-          <li>50% functionality in place</li>
+          <li>A public, searchable documentation site</li>
+          <li>Controlled editing and publishing through a headless CMS</li>
+          <li>Component guidance moved from Confluence and Google Docs</li>
+          <li>Links to the tools where design and code work already lived</li>
+          <li>Basic SEO, analytics, and a feedback form</li>
+          <li>A support path through Slack and Jira</li>
         </ul>
-
-        <h3>3 Months (Beta)</h3>
-
+        <h3>Out of scope</h3>
         <ul>
           <li>
-            Headless CMS in place and content structured for
-
-            <ul>
-              <li>Overview page layouts</li>
-              <li>Component page layouts</li>
-            </ul>
+            Public code examples before the component library was ready for
+            public access
           </li>
-          <li>CI/CD in place with the headless CMS</li>
-          <li>Theme has incrementally gotten closer to our branding</li>
+          <li>Embedded Figma components while the libraries stayed private</li>
           <li>
-            Training and onboarding for authenticated users to fill out content
-            in their designated areas
+            Moving the site into the app monorepo before the engineering team
+            could support it
           </li>
-          <li>75% functionality in place</li>
+          <li>A full comment system or blog at launch</li>
+          <li>
+            Waiting for every page. The design system team could launch when 80
+            percent of the agreed content was ready.
+          </li>
         </ul>
 
-        <h3>6 Months (GA Release)</h3>
-
-        <ul>
-          <li>All teams are ramped on on content production</li>
-          <li>We're refining the layout and design, but it's on brand</li>
-          <li>Adding nice-to-have features</li>
-          <li>
-            Set up a support channel on Slack for bugs/requests
-            <ul>
-              <li>Set up a area in Jira for tracking bugs/requests</li>
-              <li>Linking Jira to Slack channel for notifications</li>
-            </ul>
-          </li>
-          <li>100% functionality in place</li>
-        </ul>
-        <h2>Designs / Mocks</h2>
+        <h2>Choose Measures Before Building</h2>
         <p>
-          <em
-            >Visuals to help aid in getting the message across. Low fidelity is
-            fine here.</em
-          >
+          The spec proposed a 10 percent increase in documentation satisfaction
+          across the next three quarterly surveys. It also called for tracking
+          search behavior, feedback, component references during product
+          research, and visits to the public site.
         </p>
-        <h3>Sitemap</h3>
+        <p>
+          Those measures still needed baselines and owners. Writing them down
+          exposed that work before anyone treated a page view as proof of
+          success.
+        </p>
+
+        <h2>Keep the Exit Open</h2>
+        <p>
+          This was a reversible decision. If the new site failed, teams could
+          keep using Confluence and Google Docs while we fixed it. If the CMS
+          caused trouble, Astro could serve Markdown files until the content was
+          moved.
+        </p>
+        <p>
+          The proposed release plan named deliverables instead of one big date:
+        </p>
+        <ul>
+          <li>
+            <strong>One month:</strong> A repeatable local build, a repository, and
+            a hosted site frame.
+          </li>
+          <li>
+            <strong>Three months:</strong> A connected CMS, content models for overview
+            and component pages, a closer brand fit, and contributor training.
+          </li>
+          <li>
+            <strong>Six months:</strong> Working content routines, a support path,
+            and a general release when the agreed content threshold was met.
+          </li>
+        </ul>
+
+        <h2>Map the Site Before the Pages</h2>
+        <p>
+          The sitemap made the content model visible. It gave the team something
+          concrete to question before we spent time polishing pages.
+        </p>
         <Picture
           src={ascentSitemap}
           widths={[300, 800, 2000, ascentSitemap.width]}
           sizes={`(max-width: 300px) 300px, (max-width: 800px) 800px, (max-width: 1600px) 2000px, ${ascentSitemap.width}px`}
           pictureAttributes={{
-            class:
-              'object-contain h-full w-full row-start-1 row-span-5 col-start-1 col-span-12 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-1 ',
+            class: 'object-contain h-full w-full',
           }}
-          class={'object-contain h-full w-full row-start-1 row-span-5 col-start-1 col-span-12 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-1 '}
-          alt="Ascent Design System FigJam sitemap"
+          class={'object-contain h-full w-full'}
+          alt="Ascent Design System sitemap"
           formats={['avif', 'webp']}
           loading="lazy"
         />
-        <h2>Technical Concerns / Outstanding Questions</h2>
 
+        <h2>Leave Open Questions Open</h2>
         <p>
-          <em
-            >Big open questions, or questions that cannot be answered until you
-            start getting into the weeds.</em
-          >
+          A useful spec does not pretend every choice is settled. This one kept
+          the hard questions in view:
         </p>
         <ul>
+          <li>Which headless CMS fits the content and access model?</li>
           <li>
-            Headless CMS to use <br />
-            <em
-              >The following are recommended due to research and prior
-              experience</em
-            >
-          </li>
-          <ul>
-            <li><a href="https://www.sanity.io/" target="_blank">Sanity</a></li>
-            <li><a href="https://directus.io/" target="_blank">Directus</a></li>
-            <li>
-              <a href="https://keystatic.com/" target="_blank">Keystatic</a>
-            </li>
-          </ul>
-          <li>
-            Deployment server (host) <br />
-            <em
-              >The following are recommended due to the speed in which we can
-              get CI/CD up and running</em
-            >
-            <ul>
-              <li>
-                <a href="https://www.netlify.com/" target="_blankx">Netlify</a>
-              </li>
-              <li><a href="https://vercel.com/" target="_blank">Vercel</a></li>
-            </ul>
+            Should the site use Astro or Starlight, or follow the app team's
+            interest in Next.js?
           </li>
           <li>
-            <span id="dagger-01">†</span> For the initial GA release, we won't everything
-            publicly available. There will be some extra steps for internal team
-            members to access certain aspects. More seamless integration will come
-            after GA release or we simply will not launch on time.
+            Which parts can be public at launch, and which must stay private?
           </li>
           <li>
-            <span id="dagger-02">††</span> Do we want to set up Hotjar for behavior
-            tracking?
+            When can the component library and Figma libraries support live
+            examples?
           </li>
-          <li>
-            Leaning towards <a href="https://astro.build" target="_blank"
-              >Astro</a
-            >, or specifically <a
-              href="https://starlight.astro.build/"
-              target="_blank"
-            >
-              Astro Starlight
-            </a> with a headless CMS for a team to easily update content
-          </li>
-          <li>
-            The engineering team, generally, wants to move the app itself to
-            Next.js
-
-            <ul>
-              <li>
-                Do we want to consider that for the documentation site front-end
-                since our company is full of React developers?
-              </li>
-            </ul>
-          </li>
-          <li>
-            Do we want to eventually pull this into the app monorepo?
-            <ul>
-              <li>
-                our component library ever going to be abstracted for public
-                consumption like our peers <a
-                  href="https://polaris.shopify.com/"
-                  target="_blank"
-                >
-                  Shopify with Polaris
-                </a>?
-              </li>
-            </ul>
-          </li>
+          <li>Should the site ever move into the app monorepo?</li>
+          <li>What behavior data is useful without becoming noise?</li>
         </ul>
-        <h3>Future</h3>
-        <ul>
-          <li>
-            We'll want to make this a hybrid SSG/SSR site for dynamic features,
-            like quick feedback thumbs
-          </li>
-          <li>
-            We'd like to build out blogging functionality to so we can have a
-            platform to distribute content
-          </li>
-          <li>Component library access for live code examples in the site</li>
-        </ul>
+        <p>
+          That is why the spec mattered. It showed what the team could agree on,
+          what we were excluding, and which decisions still needed an owner.
+        </p>
       </div>
     </div>
   </section>

--- a/src/pages/portfolio/klaviyo-asecnt-design-system-documentation-site.astro
+++ b/src/pages/portfolio/klaviyo-asecnt-design-system-documentation-site.astro
@@ -11,7 +11,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 <InnerLayout
   subtitle="A product spec for turning Klaviyo's scattered design system documentation into one useful home."
   meta={{
-    title: 'Klaviyo: Ascent Design System Documentation Site',
+    title: 'Klaviyo: Ascent Design System documentation site',
     description:
       'Case study of the Ascent Design System documentation site for Klaviyo, from the portfolio of Frank Stallone',
     canonicalURL: canonicalURL.href,
@@ -40,7 +40,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">The Spec Was the Work</h2>
+          <h2 class="mt-zero">The spec was the work</h2>
           <p>
             This page explores a public home for Klaviyo's Ascent Design System.
             The main artifact is a mock product spec based on the RFC process I
@@ -70,7 +70,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 
     <div class="region wrapper">
       <div class="flow case-panel center" style="--measure: 60ch;">
-        <h2 class="mt-zero">Start With the Mess</h2>
+        <h2 class="mt-zero">Start with the mess</h2>
         <p>
           Ascent already had the parts of a design system: Figma UI kits, a
           React component library, design tokens built with Style Dictionary,
@@ -84,7 +84,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           how to use it.
         </p>
 
-        <h2>Write Down Who Needs It</h2>
+        <h2>Write down who needs it</h2>
         <p>
           The site had to serve product owners, designers, content designers,
           data scientists, engineers, and leadership. A public site could also
@@ -111,7 +111,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           </li>
         </ul>
 
-        <h2>Make the First Release Small Enough</h2>
+        <h2>Make the first release small enough</h2>
         <p>
           The proposal called for a static site connected to a headless CMS.
           Publishing in the CMS would trigger a new build. The first release
@@ -146,7 +146,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           </li>
         </ul>
 
-        <h2>Choose Measures Before Building</h2>
+        <h2>Choose measures before building</h2>
         <p>
           The spec proposed a 10 percent increase in documentation satisfaction
           across the next three quarterly surveys. It also called for tracking
@@ -159,7 +159,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           success.
         </p>
 
-        <h2>Keep the Exit Open</h2>
+        <h2>Keep the exit open</h2>
         <p>
           This was a reversible decision. If the new site failed, teams could
           keep using Confluence and Google Docs while we fixed it. If the CMS
@@ -184,7 +184,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           </li>
         </ul>
 
-        <h2>Map the Site Before the Pages</h2>
+        <h2>Map the site before the pages</h2>
         <p>
           The sitemap made the content model visible. It gave the team something
           concrete to question before we spent time polishing pages.
@@ -202,7 +202,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           loading="lazy"
         />
 
-        <h2>Leave Open Questions Open</h2>
+        <h2>Leave open questions open</h2>
         <p>
           A useful spec does not pretend every choice is settled. This one kept
           the hard questions in view:

--- a/src/pages/portfolio/klaviyo-asecnt-design-system-phone-input.astro
+++ b/src/pages/portfolio/klaviyo-asecnt-design-system-phone-input.astro
@@ -44,7 +44,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-1 md:row-span-6 md:col-start-7 md:col-span-7 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Phone Numbers Aren't Simple</h2>
+          <h2 class="mt-zero">Phone numbers aren't simple</h2>
           <p>
             A phone number input looks small until it has to work across
             countries, locales, validation states, and the rest of an app.
@@ -83,7 +83,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-2 md:row-span-4 md:col-start-2 md:col-span-8 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Align the Teams First</h2>
+          <h2 class="mt-zero">Align the teams first</h2>
           <p>
             This started with a prioritized component list and Klaviyo's move
             into international markets. We already had a Number Input, but its
@@ -129,7 +129,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-1 md:row-span-3 md:col-start-6 md:col-span-6 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Turn Requirements Into Rules</h2>
+          <h2 class="mt-zero">Turn requirements into rules</h2>
           <p>
             With the requirements, existing patterns, and outside research in
             front of me, I started sketching. The point was to make the
@@ -204,7 +204,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-1 md:row-span-4 md:col-start-1 md:col-span-6 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Make It Fit the System</h2>
+          <h2 class="mt-zero">Make it fit the system</h2>
           <p>
             I start fast in Figma. Early exploration does not need every Style
             and Variant in place. Refinement is where the work has to fit the
@@ -273,7 +273,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
     </div>
     <div class="region wrapper">
       <div class="case-panel center flow prose" style="--measure: 50ch;">
-        <h2>Build It to Find the Compromises</h2>
+        <h2>Build it to find the compromises</h2>
         <div>
           <PhoneInput client:idle />
         </div>

--- a/src/pages/portfolio/klaviyo-asecnt-design-system-phone-input.astro
+++ b/src/pages/portfolio/klaviyo-asecnt-design-system-phone-input.astro
@@ -9,9 +9,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="Creating 'just' another phone number input for Klaviyo's Ascent Design System subscribers."
+  subtitle="A phone number input for Klaviyo's Ascent Design System. Simple on the surface. Not simple underneath."
   meta={{
-    title: 'Klaviyo Ascent Design System: Phone input',
+    title: 'Klaviyo Ascent Design System: Phone number input',
     description:
       'Case study of the Ascent Design System Phone number input for Klaviyo, from the portfolio of Frank Stallone',
     canonicalURL: canonicalURL.href,
@@ -44,40 +44,33 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-1 md:row-span-6 md:col-start-7 md:col-span-7 flow case-panel z-10"
         >
-          <h2 class="mt-zero">The Challenge</h2>
+          <h2 class="mt-zero">Phone Numbers Aren't Simple</h2>
           <p>
-            What could be more simple than creating a Phone Number component?
-            Constructing a simple yet powerful component that was ready for the
-            future of the Klaviyo app, and work well for the marketing team.
+            A phone number input looks small until it has to work across
+            countries, locales, validation states, and the rest of an app.
           </p>
           <p>
-            The challenge here was to consider all of the possible ways to
-            layout an input, in the context of others, that gave the user
-            affordances to choose their country, and handling validation for
-            such a renown complex component.
+            The component needed to give people a clear country choice, format
+            the mask and placeholder for that country, and stay visually
+            consistent with Klaviyo.
           </p>
           <p>
-            Through discussions with the stakeholders I was able to acquire some
-            insight into previously used solutions by the marketing team, where
-            they wanted to go, and pulled that all into my research document.
-            There were a few stand out features that came became primary
-            priorities:
+            I spoke with stakeholders about the marketing team's earlier
+            solutions and where they needed to go. That research made three
+            priorities clear:
           </p>
           <ul>
             <li>
-              Representing different countries, with a default based on the
-              app's locale
+              Represent each country, with a default based on the app's locale
             </li>
             <li>
-              Phone number formatting of the input mask and placeholder based on
-              the country
+              Format the input mask and placeholder for the selected country
             </li>
-            <li>Consistent look and feel with the rest of the Klaviyo app</li>
+            <li>Match the look and feel of the Klaviyo app</li>
           </ul>
           <p>
-            Getting these primary considerations together, and in alignment with
-            stakeholders, meant the product and marketing teams would be able to
-            use this single component for their use cases.
+            The goal was one component that product and marketing teams could
+            use without solving the same problem twice.
           </p>
         </div>
       </div>
@@ -90,37 +83,30 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-2 md:row-span-4 md:col-start-2 md:col-span-8 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Discovery and Collaboration</h2>
+          <h2 class="mt-zero">Align the Teams First</h2>
           <p>
-            This particular journey begins with an extensive list of prioritized
-            components and the organizations larger initiative to enter the
-            international space. We had an existing component that was similar,
-            the Number Input, however the variations for this input were growing
-            on it's own without putting in logic for phone numbers.
+            This started with a prioritized component list and Klaviyo's move
+            into international markets. We already had a Number Input, but its
+            variations were growing without phone number logic.
           </p>
           <p>
-            In talking to a few different team leaders I created a list of
-            stakeholders who had a vested interest in the results. These
-            stakeholders included Directors of Product Design, and Engineering
-            Managers on both the app team, and marketing team. I also consulted
-            with other Lead Product Designers who had related expertise. I
-            scheduled interviews with these individuals to inform them on my
-            process, gather any requirements or requests to create user stories,
-            and let them know how I would be communicating progress through
-            Jira.
+            I mapped the people who needed a say: Product Design directors,
+            Engineering Managers from the app and marketing teams, and Lead
+            Product Designers with related experience. I interviewed them for
+            requirements and user stories, then used Jira to keep progress
+            visible.
           </p>
           <p>
-            While waiting for those meetings, I starting a FigJam pulling in
-            existing references from our Number Input and commenting on
-            similarities and differences. I then performed cursory research into
-            what other design systems were doing for a Phone Number input, also
-            searching a few design system communities. I laughed &mdash; I had
-            personal experience designing and developing the Roll by ADP Phone
-            Number React input, and saw the same complex logic discussions and
-            trade offs in older online community threads. Specifically, I
-            remember dealing with the definitive phone number formatting and
-            parsing library, developed by Google. It's JavaScript port is 8MB
-            which drastically affects web app performance.
+            While those conversations were getting scheduled, I built a FigJam
+            from the existing Number Input. I marked what carried over and what
+            did not. I also looked at how other design systems and communities
+            handled phone number inputs.
+          </p>
+          <p>
+            I had built the Roll by ADP phone number React input before, so the
+            tradeoffs looked familiar. Accurate phone number formatting often
+            requires a large dependency. Correctness has a real performance
+            cost.
           </p>
         </div>
         <Picture
@@ -143,76 +129,56 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-1 md:row-span-3 md:col-start-6 md:col-span-6 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Ideation and Design</h2>
+          <h2 class="mt-zero">Turn Requirements Into Rules</h2>
           <p>
-            Taking a step back to look at all of the data and information
-            collected from stakeholders, existing component methodology, and
-            research guidelines and UX from other design systems I'm armed with
-            everything I need to make decisions about how this component will
-            look and feel. This is where the whiteboard or sketchpad comes in
-            handy. I'll take themes that start to develop and sketch them out.
+            With the requirements, existing patterns, and outside research in
+            front of me, I started sketching. The point was to make the
+            decisions visible before locking them into Figma.
           </p>
           <p>
-            At the same time, I am writing a template we created for the design
-            system team to organize our documentation of the component. This
-            includes:
+            At the same time, I documented the component with the design system
+            team's template. It covered:
           </p>
           <ul>
             <li>
               Best practices
               <ul>
-                <li>What to use</li>
-                <li>When not to use</li>
+                <li>When to use it</li>
+                <li>When not to use it</li>
               </ul>
             </li>
             <li>Related components</li>
-            <li>Internal components (that will be used in this component)</li>
+            <li>Internal components used by this component</li>
             <li>Rules</li>
             <li>
               Behaviors
               <ul>
                 <li>
-                  States: Describing each state the component can be in, and the
-                  expectations
+                  States: Each state the component can be in and its expected
+                  behavior
                 </li>
                 <li>
-                  Interactions: Describing the mouse, keyboard, and screen
-                  reader expectations
+                  Interactions: Mouse, keyboard, and screen reader expectations
                 </li>
               </ul>
             </li>
             <li>
               Content
               <ul>
-                <li>
-                  Working with the Content design team to align with best
-                  practices, and set expectations
-                </li>
+                <li>Content Design guidance and expectations</li>
               </ul>
             </li>
           </ul>
           <p>
-            During our regular stand ups with the team, we critique everyones
-            work. This is where I bring up to the team my progress, and discuss
-            best practice decisions. After those critiques, I will update the
-            stakeholders to ensure they are on board, with the right level of
-            detail. For instance, a Product Owners may only need a written
-            bulleted list of what's been done, and whether we're on track.
-            Product Designers and Engineers who are subscribers to the design
-            system, and have a vested interest in the component may get that
-            same list with visuals, or links directly to Figma for them to
-            provide feedback.
+            We reviewed the work in regular standups. I brought the decisions
+            back to the team, then updated each stakeholder at the level they
+            needed: bullets for a Product Owner; visuals and Figma links for
+            designers and engineers who needed to respond.
           </p>
           <p>
-            Let's take a moment to talk about critiques. I have successfully
-            used a few techniques throughout my career that were embedded since
-            design school around critiques. No matter what your title is, I
-            always keep the conversation related to the ideas and decisions that
-            brought us to those ideas. Doing this keeps us on track with the
-            objectives shaped from the start, and dissolves any potential
-            emotional consequences. It's never about who is doing the work, it's
-            about the work and whether that meets the needs of our users and the
-            business.
+            A critique works when it stays about the decision, not the person
+            who made it. We kept returning to the original question: does this
+            serve the user and the business?
           </p>
         </div>
         <Picture
@@ -238,19 +204,17 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="md:row-start-1 md:row-span-4 md:col-start-1 md:col-span-6 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Refinement &amp; Results</h2>
+          <h2 class="mt-zero">Make It Fit the System</h2>
           <p>
-            Since Figma is the tool of choice these days, it's worth noting that
-            I will start designing without aligning Figma Styles or Variants for
-            speed, and to explore any newer innovation a component may need.
-            During the refinement stages, I start to align closer to existing
-            component design principals that have been set by the team. In this
-            particular case, the Phone input is similar to the Text input, a
-            form component. That means sitting it in a Field component to see
-            how it works with other inputs, labels, descriptions, and error
-            messages. I'll also start applying any relevant Styles and replacing
-            any parts with existing internal components that are already solving
-            that problem.
+            I start fast in Figma. Early exploration does not need every Style
+            and Variant in place. Refinement is where the work has to fit the
+            system.
+          </p>
+          <p>
+            The Phone Input is a form control, like the Text Input, so I placed
+            it in a Field to test it with other inputs, labels, descriptions,
+            and error messages. I applied the relevant Styles and replaced parts
+            with internal components where they already solved the problem.
           </p>
           <Picture
             src={field}
@@ -260,43 +224,32 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               class: 'object-contain h-auto w-auto ',
             }}
             class={'object-contain h-auto w-auto '}
-            alt="Phone input component in a Field component showing variants"
+            alt="Phone number input component in a Field component showing variants"
             formats={['avif', 'webp']}
             loading="lazy"
           />
-          <p>
-            Coming back to the documentation for the component, this is where I
-            add:
-          </p>
+          <p>The documentation then added:</p>
           <ul>
+            <li>Visual examples of what to do and what not to do</li>
             <li>
-              Visual representations of what to do, and what not to do for the
-              Rules
+              Variants: Relevant states, how they differ from the base, and the
+              data they need
             </li>
             <li>
-              Variants: Relevant states and how they look compared to base, and
-              any relevant data
-            </li>
-            <li>
-              Anatomy: One of the visuals we use on the documentation site, and
-              in the Figma component itself is a section with redlines to
-              clearly articulate naming. This helps for describing and talking
-              about the decisions made about each of these parts that make the
-              whole
+              Anatomy: Redlines and shared names for the parts that make the
+              whole component
             </li>
           </ul>
           <p>
-            Finally we clean up the Figma file ensuring actual components are in
-            the right page, and that there is a documentation page with examples
-            of all the relevant states and considerations.
+            Finally, I cleaned up the Figma file. The components lived on the
+            right page, with a documentation page for the relevant states and
+            considerations.
           </p>
           <p>
-            The results are a well thought out component with all the design,
-            development, content, and accessibility considerations that make our
-            teams more efficient and effective at their job. We'll ensure we've
-            updated the Figma library changelog accordingly, and broadcast to
-            all stakeholders via email newsletters, Slack groups, DM's and
-            relevant calls.
+            The final handoff brought the component, its states, examples, and
+            guidance into one place. The release process then called for a Figma
+            library changelog update and announcements through email, Slack,
+            direct messages, and team calls.
           </p>
         </div>
         <video
@@ -319,14 +272,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       </div>
     </div>
     <div class="region wrapper">
-      <div class="case-panel mx-auto flow prose">
-        <h2>React component</h2>
+      <div class="case-panel center flow prose" style="--measure: 50ch;">
+        <h2>Build It to Find the Compromises</h2>
         <div>
           <PhoneInput client:idle />
         </div>
         <p>
-          What does this look like as a React component? Functionally, we have
-          this <code>PhoneInput</code>
+          Here is the React prototype. The <code>PhoneInput</code>
           <a
             href="https://github.com/frankstallone/frankstall.one/blob/main/src/components/ui/PhoneInput.tsx"
           >
@@ -338,15 +290,14 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               ><path
                 d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"
               ></path></svg
-            > working correctly
-          </a> with some caveats. The world is imperfect. When thinking about that
-          conversation between design and development, compromises need to occur.
+            > source
+          </a> works, with caveats. The world is imperfect. Design and development
+          have to make tradeoffs.
         </p>
         <p>
-          Input masking is a good example. The design called for the country
-          code to be in place. Doing so is more of a challenge. Another user
-          experience consideration is what happens to numbers already input,
-          after the <code>CountrySelector</code>
+          Input masking is one example. The design called for the country code
+          to stay in place. That is harder than it sounds. Another question:
+          what should happen to a number after the <code>CountrySelector</code>
           <a
             href="https://github.com/frankstallone/frankstall.one/blob/main/src/components/ui/CountrySelector.tsx"
           >
@@ -358,26 +309,22 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
               ><path
                 d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"
               ></path></svg
-            > component
-          </a> is updated? Currently, we clear the field. Is that the best UX?
+            > source
+          </a> changes? This prototype clears the field. Is that the right experience?
         </p>
         <p>
-          Other trade offs are with the dependencies we use. Do we build the
-          input mask and formatter by hand? I've decided to use a dependency for
-          input masking, formatting, and the custom select menu. These
-          dependencies come with their own problems. For instance, the <code
-            >radix</code
-          > dependency has an SVG icon when toggling on <code
-            >position="popper</code
-          >. This icon has no class, or data attribute, or option to toggle off.
-          Therefore, I have kept Radix's native MacOS menu style for the portal.
+          Dependencies create their own tradeoffs. I used libraries for input
+          masking, formatting, and the custom select menu instead of building
+          them by hand. Radix, for example, adds an SVG icon when <code
+            >position="popper"</code
+          > is enabled. In this prototype, I could not remove or target that icon,
+          so I kept Radix's native macOS menu style for the portal.
         </p>
         <p>
-          As a prototype of this being built in React, I'm pleased. We have all
-          the elements and everything is accessible for keyboard users. For
-          production, I would go deeper into the pros and cons of using these
-          depenedencies, look for more options, and read into what other
-          community members have done in the past.
+          As a React prototype, it has the core pieces and keyboard access.
+          Before production, I would test the dependency choices more deeply,
+          compare alternatives, and study how others have handled the same
+          problems.
         </p>
       </div>
     </div>

--- a/src/pages/portfolio/loumarc-signs.astro
+++ b/src/pages/portfolio/loumarc-signs.astro
@@ -12,7 +12,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="After 30 years in business, Loumarc Signs needed a complete brand refresh to attract a new generation of custom sign buyers."
+  subtitle="Loumarc Signs had 30 years of craft and a brand that no longer matched the work. I helped define what came next."
   meta={{
     title: 'Loumarc Signs',
     description:
@@ -27,23 +27,18 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">The Challenge</h2>
+          <h2 class="mt-zero">The brand had fallen behind the work</h2>
           <p>
-            When Loumarc Signs approached me, I faced an exciting yet daunting
-            challenge: help a brand with 30 years of craft redefine its
-            identity. The company had evolved from humble beginnings into a
-            high-end custom sign company, but their brand image hadn't kept pace
-            with their growth. My task was to elevate their image to align with
-            their changing clientele and improved product and service offerings,
-            while also increasing year-over-year revenue.
+            Loumarc Signs had grown into a custom sign company serving larger
+            clients, but its identity still looked like an earlier version of
+            the business. The work, service, and customers had changed. The
+            brand had not.
           </p>
           <p>
-            The core of the challenge lay in uncovering who Loumarc Signs had
-            become over three decades, understanding their current customers'
-            perceptions, and envisioning who they aspired to be in the future.
-            This wasn't just a visual makeover &mdash; it was about crafting a
-            comprehensive brand strategy that would resonate with their upscale
-            market positioning.
+            We needed to understand what 30 years had built, where the company
+            wanted to go, and what its best customers already valued. The
+            business goal was to attract a new generation of buyers and support
+            year over year revenue growth. A new logo alone would not do that.
           </p>
         </div>
         <Picture
@@ -62,45 +57,40 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       </div>
     </div>
     <div
-      class="region wrapper flex flex-col flow md:grid"
+      class="region wrapper flex flex-col flow md:grid md:grid-cols-12"
       data-layout="twelfths"
     >
       <div
         class="md:row-start-1 md:row-span-4 md:col-span-8 md:col-start-4 flow case-panel z-10"
       >
-        <h2 class="mt-zero">Discovery and Collaboration</h2>
+        <h2 class="mt-zero">Find out what changed</h2>
         <p>
-          I kicked off with an in-depth conversation with the owner, discussing
-          business goals and defining metrics for success. This initial dialogue
-          was crucial in setting the stage for our rebranding journey and
-          agreeing on the right level of engagement.
+          I started with the owner. We talked through the business goals, how we
+          would measure progress, and how much of the company the work needed to
+          touch.
         </p>
         <p>
-          Armed with a whiteboard, Keynote presentation workbook, post-it notes,
-          and markers, I convened a diverse group of stakeholders in the
-          company's boardroom. This group included long-standing associates
-          crucial to the company's success and those with fresh perspectives to
-          share.
+          Then I brought a group of stakeholders into the boardroom with a
+          whiteboard, a Keynote workbook, notes, and markers. The group mixed
+          people who had helped build Loumarc with people who could see it with
+          fresh eyes.
         </p>
-        <p>Our discovery workshop was divided into three distinct sections:</p>
+        <p>The workshop covered three parts:</p>
         <ol class="flow">
-          <li>Brand Substance</li>
-          <li>Brand Position</li>
-          <li>Brand Expression</li>
+          <li>Brand substance</li>
+          <li>Brand position</li>
+          <li>Brand expression</li>
         </ol>
         <p>
-          We dove into exercises to understand their audience, competitors, and
-          the overall landscape of the custom sign world. We went deeper,
-          gaining clarity on Loumarc Signs' identity, their ideal audience,
-          their reason for existence aside from making money, and their key
-          differentiators.
+          We mapped the audience, competitors, purpose, and differences that
+          mattered. The work showed us who Loumarc was for, why customers chose
+          it, and which parts of the company should not change.
         </p>
         <p>
-          The brand substance and position sections are intended for their
-          internal team – defining who they are, their audience, competition,
-          and unique selling points. This foundational work allowed us to create
-          a brand persona, including voice and tone, and story framework. The
-          brand expression section then guided all external communications.
+          Brand substance and position gave the internal team a shared way to
+          make decisions. Brand expression turned that foundation into a
+          persona, voice, tone, story, and visual direction for customers to
+          see.
         </p>
       </div>
       <Picture
@@ -122,54 +112,40 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-1 md:col-span-6 flow case-panel"
         >
-          <h2 class="mt-zero">Brand Summary and Logo Design</h2>
+          <h2 class="mt-zero">Turn the workshop into a brief</h2>
           <p>
-            Armed with days' worth of workshop outcomes, I prepared a concise
-            brand strategy summary for the team. This document served as our
-            North Star as we moved into the creative phase.
+            I condensed the workshop into a brand strategy summary. It gave the
+            team and the logo designers one brief to judge the work against.
           </p>
           <p>
-            I began by sourcing logo designers whose work reflected
-            characteristics that would resonate with the new brand. We embarked
-            on creating a new logo mark and wordmark that would encapsulate
-            Loumarc Signs' elevated status.
+            I found logo designers whose work fit the direction, then led the
+            development of a new mark and wordmark for Loumarc Signs.
           </p>
           <p>
-            The logo design process was iterative and collaborative. After weeks
-            of refining sketches, virtual critiques, and revisiting our workshop
-            results, we narrowed it down to four standout logos. We paired these
-            with carefully selected typefaces, creating unique wordmarks with
-            modified letter forms to resonate with its logo mark.
-            Simultaneously, we conducted a color study and collaborated with the
-            client to develop a new color palette that reflected their upscale
-            positioning.
+            After weeks of sketches, critiques, and revisions, we narrowed the
+            work to four options. Each paired a mark with a custom wordmark. We
+            also studied type and color with the client so every option worked
+            as a complete identity, not an isolated logo.
           </p>
         </div>
         <div
-          class="row-start-13 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-7 md:col-span-7 flow case-panel"
+          class="row-start-13 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-7 md:col-span-6 flow case-panel"
         >
-          <p class="mt-zero">
-            The logo presentation was a meticulously planned event. I gathered
-            the same panel of stakeholders and began by discussing what makes
-            iconic logos effective, reviewed our objectives, and presented the
-            current state of their brand. Then, I unveiled the new logos and
-            wordmarks.
+          <h2 class="mt-zero">Give the team a real choice</h2>
+          <p>
+            I brought the workshop group back together. Before showing any new
+            work, I reviewed the brief, the limits of the old identity, and the
+            qualities that make a logo useful.
           </p>
           <p>
-            Each logo mark was presented in different variations, in black and
-            white, with explanations of their unique qualities and how they
-            aligned with the brand and audience. We also showcased each logo in
-            different real-world applications to help stakeholders visualize
-            their impact.
+            I presented every option in black and white, in several variations,
+            and in the places where customers would see it. The mockups made the
+            tradeoffs easier to discuss than a logo floating on a slide.
           </p>
           <p>
-            The presentation was met with enthusiasm. As I walked the room
-            through each slide, articulating our design decisions, I could hear
-            positive reactions from the team. I maintained objectivity
-            throughout, carefully explaining the merits of each option without
-            showing favoritism, even when answering questions. The final
-            decision was a collaborative effort, with the team reaching a
-            consensus after thoughtful discussion and debate.
+            My job was to explain the strengths of each direction without
+            choosing for the room. The stakeholders asked questions, debated the
+            options, and reached a shared decision.
           </p>
         </div>
       </div>
@@ -178,62 +154,50 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <LoumarcGrid />
     </div>
     <div class="region wrapper">
-      <div class="flex flex-col flow md:grid" data-layout="twelfths">
+      <div
+        class="flex flex-col flow md:grid md:grid-cols-12"
+        data-layout="twelfths"
+      >
         <div
-          class="md:row-start-1 md:row-span-12 md:col-start-1 md:col-span-6 flow case-panel z-10"
+          class="min-w-0 md:row-start-1 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h2 class="mt-zero">The Result</h2>
+          <h2 class="mt-zero">Build the brand into the business</h2>
           <p>
-            Throughout the logo design process, I was simultaneously crafting a
-            comprehensive brand guide. This document distilled the outcomes of
-            our workshop into a blueprint for decision-making across the
-            organization. It covered everything from aligning business decisions
-            with their purpose, vision, values, and mission, to writing
-            marketing materials using their brand persona voice and tone.
+            I built the brand guide while the identity took shape. It turned the
+            workshop into a system for decisions across the company, from
+            purpose, vision, values, and mission to voice, tone, and marketing.
           </p>
-          <p>
-            With the new brand identity in place, we moved on to creating
-            tangible assets:
-          </p>
+          <p>Then we put that system to work:</p>
           <ol class="flow">
             <li>
-              <strong>Business Cards</strong>: We designed and printed
-              high-quality business cards that embodied their new upscale
-              branding.
+              <strong>Business cards:</strong> We designed and printed the first physical
+              expression of the new identity.
             </li>
             <li>
-              <strong>Website</strong>: I <a
+              <strong>Website:</strong> I <a
                 href="https://loumarcsigns.com/"
                 target="_blank">designed and developed a new website</a
-              > using a modern web framework and headless CMS, perfectly aligned
-              with their new direction. The page layouts were optimized for comprehensive
-              SEO techniques and conversion.
+              > with a modern web framework and headless CMS. The page structure supported
+              search and conversion.
             </li>
             <li>
-              <strong>Content Strategy</strong>: Working with a specialist, we
-              conducted a deep keyphrase analysis, providing Loumarc Signs with
-              an endless well of organic content marketing material.
+              <strong>Content research:</strong> A specialist helped us map the keyphrases
+              customers used and the topics Loumarc could own.
             </li>
             <li>
-              <strong>AI-Assisted Content Creation</strong>: Leveraging the
-              emerging field of GenAI, I used the brand guide to construct
-              prompts for ChatGPT and other AI tools. This innovative approach
-              to content creation, guided by our well-articulated brand
-              strategy, yielded impressive results.
+              <strong>AI content tools:</strong> I turned the brand guide into prompts
+              for ChatGPT and other tools so generated drafts still had clear voice
+              rules.
             </li>
             <li>
-              <strong>Social Media and Content Machine</strong>: I created
-              documentation, video tutorials, and trained a social marketing
-              team to use the keyphrase analysis in a content machine, a Notion
-              workspace for organizing and collaborating on short and long-form
-              content creation.
+              <strong>Publishing system:</strong> I built a Notion workspace, wrote
+              documentation, recorded tutorials, and trained the social team to plan
+              short and long form content.
             </li>
           </ol>
           <p>
-            After six months of intense collaboration, design, development, and
-            implementation, the new Loumarc Signs brand came to life. We
-            meticulously updated all their online properties to ensure
-            consistent brand representation across all touchpoints.
+            Over six months, we moved from workshop notes to a working identity,
+            website, content system, and updated online presence.
           </p>
         </div>
         <Picture
@@ -242,9 +206,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           sizes={`(max-width: 300px) 300px, (max-width: 700px) 700px, ${brandPersona.width}px`}
           pictureAttributes={{
             class:
-              'object-contain w-full h-full md:row-start-1 md:row-span-6 md:col-start-7 md:col-span-6 ',
+              'min-w-0 object-contain w-full h-full md:row-start-1 md:col-start-7 md:col-span-6 ',
           }}
-          class={'object-contain w-full h-full md:row-start-1 md:row-span-6 md:col-start-7 md:col-span-6 '}
+          class={'min-w-0 object-contain w-full h-full md:row-start-1 md:col-start-7 md:col-span-6 '}
           alt="Brand persona from Loumarc Signs Brand Guide"
           formats={['avif', 'webp']}
           loading="lazy"
@@ -255,33 +219,28 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           sizes={`(max-width: 300px) 300px, (max-width: 700px) 700px, ${archetype.width}px`}
           pictureAttributes={{
             class:
-              'object-contain w-full h-full md:row-start-7 md:row-span-6 md:col-start-7 md:col-span-6 ',
+              'min-w-0 object-contain w-full h-full md:row-start-2 md:col-start-7 md:col-span-6 ',
           }}
-          class={'object-contain w-full h-full md:row-start-7 md:row-span-6 md:col-start-7 md:col-span-6 '}
+          class={'min-w-0 object-contain w-full h-full md:row-start-2 md:col-start-7 md:col-span-6 '}
           alt="Brand persona from Loumarc Signs Brand Guide"
           formats={['avif', 'webp']}
           loading="lazy"
         />
         <div
-          class="md:row-start-13 md:row-span-4 md:col-start-3 md:col-span-7 flow case-panel z-10"
+          class="min-w-0 md:row-start-2 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
+          <h2 class="mt-zero">The work finally matched the company</h2>
           <p>
-            The impact was significant and measurable. The <a
-              href="https://loumarcsigns.com/"
-              target="_blank">new website</a
-            > increased both the quality and volume of lead generation. The elevated
-            brand image resonated with their target audience, attracting more high-end
-            clients and projects. Most importantly, Loumarc Signs now had a brand
-            that truly reflected their expertise, craftsmanship, and position in
-            the market.
+            The <a href="https://loumarcsigns.com/" target="_blank"
+              >new website</a
+            >
+            brought in more leads and better fit leads. The identity also helped Loumarc
+            attract the larger clients and projects it wanted.
           </p>
           <p>
-            This project exemplifies how a comprehensive rebranding effort,
-            rooted in deep strategic thinking and executed with attention to
-            detail, can transform a business. From discovery to implementation,
-            every step was taken with Loumarc Signs' unique identity and
-            aspirations in mind, resulting in a brand that not only looks great
-            but also drives tangible business results.
+            Loumarc now had one system that connected business decisions, visual
+            design, writing, and publishing. The brand finally reflected the
+            craft that had been there for 30 years.
           </p>
         </div>
       </div>

--- a/src/pages/portfolio/roll-by-adp.astro
+++ b/src/pages/portfolio/roll-by-adp.astro
@@ -27,7 +27,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">Make Payroll Feel Small</h2>
+          <h2 class="mt-zero">Make payroll feel small</h2>
           <p>
             I joined ADP Innovation Labs to help turn a traditional payroll
             system into a mobile experience for small business owners. We wanted
@@ -59,7 +59,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <div
         class="row-start-3 row-span-4 col-start-1 col-span-12 md:row-span-4 md:col-span-8 md:row-start-2 md:col-start-4 flow case-panel z-10"
       >
-        <h2 class="mt-zero">Narrow the First Problem</h2>
+        <h2 class="mt-zero">Narrow the first problem</h2>
         <p>
           The team brought more than 40 years of combined payroll and <abbr
             title="Human Capital Management">HCM</abbr
@@ -111,7 +111,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-1 md:col-span-6 flow case-panel"
         >
-          <h2 class="mt-zero">Keep the Common Work Visible</h2>
+          <h2 class="mt-zero">Keep the common work visible</h2>
           <p>
             I sketched while our <abbr title="Subject Matter Experts">SMEs</abbr
             >
@@ -138,7 +138,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-13 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-7 md:col-span-7 flow case-panel"
         >
-          <h2 class="mt-zero">Pressure Test the Layout</h2>
+          <h2 class="mt-zero">Pressure test the layout</h2>
           <p>
             I moved the approved wireframe into high fidelity mockups. I laid
             out the accordion panels, made room for more actions, and arranged
@@ -169,7 +169,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="min-w-0 md:row-start-1 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h2 class="mt-zero">Build the Pattern, Not Just the Screen</h2>
+          <h2 class="mt-zero">Build the pattern, not just the screen</h2>
           <p>
             I built the approved design as compound React components in
             Storybook. Flexbox let the employee rows adapt across screen sizes
@@ -199,7 +199,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="min-w-0 md:row-start-2 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h2 class="mt-zero">Ship It Into the App</h2>
+          <h2 class="mt-zero">Ship it into the app</h2>
 
           <p>
             I shipped a beta of the component library with the new AccordionList
@@ -228,7 +228,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="min-w-0 md:row-start-3 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h3>Thirty Seconds a Week</h3>
+          <h3>Thirty seconds a week</h3>
           <p>
             Roll turned a dense payroll process into a focused mobile flow. The
             accordion kept the common work close and the unusual details within

--- a/src/pages/portfolio/roll-by-adp.astro
+++ b/src/pages/portfolio/roll-by-adp.astro
@@ -12,7 +12,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
 ---
 
 <InnerLayout
-  subtitle="Revamping Roll by ADP, I transformed complex payroll processes into an intuitive mobile experience, focusing on simplifying payroll HCM and HR management for small business owners."
+  subtitle="I designed and built Roll's mobile payroll experience for small business owners. The goal was simple: make payroll feel like sending a text."
   meta={{
     title: 'Roll by ADP',
     description:
@@ -27,21 +27,17 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 row-span-5 col-span-12 md:col-span-7 md:col-start-1 lg:col-span-6 lg:col-start-1 flow case-panel z-10"
         >
-          <h2 class="mt-zero">The Challenge</h2>
+          <h2 class="mt-zero">Make Payroll Feel Small</h2>
           <p>
-            As I stepped into the ADP Innovation Labs, I was faced with a
-            daunting task: transforming the complexity of traditional payroll
-            systems into a streamlined, mobile-first solution for small business
-            owners. The goal was ambitious &mdash; to make payroll management as
-            simple as sending a text message.
+            I joined ADP Innovation Labs to help turn a traditional payroll
+            system into a mobile experience for small business owners. We wanted
+            running payroll to feel as simple as sending a text.
           </p>
           <p>
-            The challenge lay in the intricate web of employee attributes:
-            payment methods, mid-cycle raises, work hours, overtime, sick time -
-            all with varying logic determined by company, location, and
-            organizational structure. How could we distill this complexity into
-            an intuitive, user-friendly application that would seamlessly fit
-            into the daily lives of busy entrepreneurs?
+            The system still had to handle payment methods, raises during a pay
+            cycle, work hours, overtime, and sick time. The rules could change
+            by company, location, and organization. The interface had to keep
+            that complexity out of the owner's way without losing it.
           </p>
         </div>
         <Picture
@@ -63,25 +59,23 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <div
         class="row-start-3 row-span-4 col-start-1 col-span-12 md:row-span-4 md:col-span-8 md:row-start-2 md:col-start-4 flow case-panel z-10"
       >
-        <h2 class="mt-zero">Discovery and Collaboration</h2>
+        <h2 class="mt-zero">Narrow the First Problem</h2>
         <p>
-          Our journey began in the main meeting room, surrounded by a diverse
-          team with over 40 years of combined payroll and <abbr
+          The team brought more than 40 years of combined payroll and <abbr
             title="Human Capital Management">HCM</abbr
-          > knowledge. From our <abbr title="Senior Vice President">SVP</abbr> of
-          Innovation to a few Product Owners, our Chief Architect, Content designer,
-          <abbr title="Quality Assurance">QA</abbr>
-          Lead, and <abbr title="Machine Learning">ML</abbr> &amp; Backend Engineers,
-          every voice at the table held value.
+          > knowledge. It included our <abbr title="Senior Vice President"
+            >SVP</abbr
+          >
+          of Innovation, Product Owners, Chief Architect, Content Designer,
+          <abbr title="Quality Assurance">QA</abbr> Lead, and <abbr
+            title="Machine Learning">ML</abbr
+          > and Backend Engineers.
         </p>
         <p>
-          I kicked off our discovery session by probing into the vast array of
-          employee attributes. As the list grew, it became clear that we needed
-          to narrow our focus even more. I asked and wrote down all the payroll
-          workflows we needed to design for and collectively decided to scope
-          our initial discussion to a single, critical flow: a manager managing
-          employee hours. Once we were happy with the design for this workflow,
-          we could come back to pressure test it on the other workflows.
+          I asked the team to list the employee data and payroll workflows we
+          needed to support. The list grew fast, so we picked one critical flow:
+          a manager entering employee hours. We would solve that first, then
+          test the design against the other workflows.
         </p>
       </div>
       <Picture
@@ -93,7 +87,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
             'object-contain h-full w-full row-start-1 row-span-5 col-start-1 col-span-12 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-1 ',
         }}
         class={'object-contain h-full w-full row-start-1 row-span-5 col-start-1 col-span-12 md:row-start-1 md:row-span-10 md:col-span-8 md:col-start-1 '}
-        alt="Small business owner smiling on a call with a customer"
+        alt="Whiteboard sketch of the employee hours workflow"
         formats={['avif', 'webp']}
         loading="lazy"
       />
@@ -106,7 +100,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
             'object-contain h-full w-full row-start-7 col-start-1 col-span-12 md:row-start-6 md:row-span-6 md:col-span-6 md:col-start-6 ',
         }}
         class={'object-contain h-full w-full row-start-7 col-start-1 col-span-12 md:row-start-6 md:row-span-6 md:col-span-6 md:col-start-6 '}
-        alt="Small business owner smiling on a call with a customer"
+        alt="High fidelity Roll payroll screen"
         formats={['avif', 'webp']}
         loading="lazy"
       />
@@ -117,62 +111,50 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
         <div
           class="row-start-1 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-1 md:col-span-6 flow case-panel"
         >
-          <h2 class="mt-zero">Ideation and Design</h2>
+          <h2 class="mt-zero">Keep the Common Work Visible</h2>
           <p>
-            Armed with insights from our <abbr title="Subject Matter Experts"
-              >SME</abbr
-            >s, I started sketching on the whiteboard, noting down attributes.
-            It quickly became apparent that some attributes were non-essential
-            for our core functionality. I could see we were essentially aiming
-            for a list of employees that managers could quickly scroll through,
-            add hours to, and submit for payroll &mdash; with minimal friction
-            and cognitive load.
+            I sketched while our <abbr title="Subject Matter Experts">SMEs</abbr
+            >
+            named the data each employee could need. Some of it mattered only in special
+            cases. The common task was much smaller: scan a list of employees, enter
+            hours, and submit payroll.
           </p>
           <p>
-            As I absorbed the requirements, a solution began to take shape in my
-            mind. I saw how an accordion design pattern could elegantly solve
-            our problem. I sketched out an example on the whiteboard, explaining
-            how this pattern could hide less common attributes like overtime,
-            bonuses, and payment types, while keeping the interface clean and
-            accessible.
+            An accordion pattern let us keep that task visible while hiding
+            overtime, bonuses, payment types, and other less common details. I
+            drew the pattern on the whiteboard so the team could react to the
+            same idea.
           </p>
           <p>
-            The team's enthusiasm grew as they saw the concept come to life. We
-            then dove into discussing the hierarchy of the main attributes. I
-            guided the team through the importance of visual hierarchy, pressing
-            them to be judicious about what becomes a main attribute to prevent
-            cognitive overload.
+            We then decided which employee details deserved to stay visible.
+            Every item added weight, so a field had to earn its place in the
+            main row.
           </p>
           <p>
-            Finally we had consensus on a wireframe. We came back to the list of
-            other workflows and proceeded to contemplate if each could be
-            accomplished with this initial design idea.
+            Once the wireframe held together, we returned to the other payroll
+            workflows and checked whether the same pattern could support them.
           </p>
         </div>
         <div
           class="row-start-13 col-start-1 row-span-12 col-span-12 md:row-start-1 md:row-span-2 md:col-start-7 md:col-span-7 flow case-panel"
         >
-          <h2 class="mt-zero">From Wireframes to High-Fidelity Mockups</h2>
+          <h2 class="mt-zero">Pressure Test the Layout</h2>
           <p>
-            With an approved wireframe in hand, I moved to create high-fidelity
-            mockups. This step was crucial in pushing the design limits and
-            considering edge cases. I meticulously laid out the accordion
-            panels, designing an area to signal additional actions to users and
-            arranging the main attributes.
+            I moved the approved wireframe into high fidelity mockups. I laid
+            out the accordion panels, made room for more actions, and arranged
+            the main employee details.
           </p>
           <p>
-            Throughout this process, I maintained an open dialogue with our
-            backend developers, clarifying data structures and contemplating how
-            to make these panel layouts pliable with flexbox. Working closely
-            with the stakeholders, we explored various scenarios: How many
-            decimal places might we encounter? What about different pay cycles?
-            How would the design hold up when translated to German?
+            I worked with Backend Engineers to understand the data and how the
+            layout could adapt with flexbox. We tested long values, different
+            pay cycles, and German translations. The layout had to bend without
+            breaking the hierarchy.
           </p>
           <p>
-            Every decision was made with accessibility in mind, considering
-            color contrast ratios, font sizes, and readability. We stripped away
-            unnecessary design elements, keeping the user focused
-          </p>on their task.
+            We checked color contrast, type size, and readability as part of the
+            design. Then we removed anything that pulled attention away from the
+            payroll task.
+          </p>
         </div>
       </div>
     </div>
@@ -180,27 +162,25 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
       <RollPortfolioGrid />
     </div>
     <div class="region wrapper flow prose">
-      <div class="flex flex-col flow md:grid" data-layout="twelfths">
+      <div
+        class="flex flex-col flow md:grid md:grid-cols-12"
+        data-layout="twelfths"
+      >
         <div
-          class="md:row-start-1 md:row-span-4 md:col-start-1 md:col-span-6 flow case-panel z-10"
+          class="min-w-0 md:row-start-1 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h2 class="mt-zero">Building the React Component</h2>
+          <h2 class="mt-zero">Build the Pattern, Not Just the Screen</h2>
           <p>
-            With approved mockups in hand, it was time to bring our designs to
-            life. I fired up Storybook and began building out compound React
-            components for our component library. Flexbox became my layout tool
-            of choice, offering the flexibility (no pun intended) we needed for
-            various screen sizes and orientations.
+            I built the approved design as compound React components in
+            Storybook. Flexbox let the employee rows adapt across screen sizes
+            and orientations.
           </p>
           <p>
-            Collaboration with our backend engineers was key during this phase.
-            We discussed data structures extensively to ensure our conversation
-            authors could easily display all the required information correctly.
-            Being the only UX/UI Designer on the team, ensuring a balance
-            between giving the backend team full control over the layout and
-            keeping the fidelity of the design output was carefully considered.
-            Ultimately, we found an elegant solution that maintained design
-            integrity while allowing for necessary flexibility.
+            The Backend Engineers needed control over the data and our
+            conversation authors needed to show the right details. As the only
+            UX and UI Designer on the team, I had to make that flexibility safe.
+            The component allowed the content to change without giving up the
+            hierarchy we had agreed on.
           </p>
         </div>
         <Picture
@@ -209,31 +189,28 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           sizes={`(max-width: 300px) 300px, (max-width: 700px) 700px, ${accordionSketch.width}px`}
           pictureAttributes={{
             class:
-              'object-contain h-full w-full md:row-start-1 md:row-span-3 md:col-span-7 md:col-start-7 ',
+              'min-w-0 object-contain h-full w-full md:row-start-1 md:col-span-6 md:col-start-7 ',
           }}
-          class={'object-contain h-full w-full md:row-start-1 md:row-span-3 md:col-span-7 md:col-start-7 '}
+          class={'min-w-0 object-contain h-full w-full md:row-start-1 md:col-span-6 md:col-start-7 '}
           alt="Sketches of the main accordion panel with variations"
           formats={['avif', 'webp']}
           loading="lazy"
         />
         <div
-          class="md:row-start-5 md:row-span-3 md:col-start-1 md:col-span-6 flow case-panel z-10"
+          class="min-w-0 md:row-start-2 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h2 class="mt-zero">Refinement and Implementation</h2>
+          <h2 class="mt-zero">Ship It Into the App</h2>
 
           <p>
-            As we approached the finish line, I shipped a beta version of our
-            component library featuring the new AccordionList component. This
-            allowed our backend developers to start integrating it into the app
-            on their local build environments.
+            I shipped a beta of the component library with the new AccordionList
+            component. Backend Engineers could then integrate it into their
+            local app builds.
           </p>
           <p>
-            This phase was essential for identifying what worked well and what
-            needed modification. It gave me the opportunity to clean up code,
-            finalize lower-priority functionality, write tests, and
-            comprehensive documentation. Throughout this process, we continually
-            referred back to our original goals, ensuring that we were truly
-            simplifying the payroll process for small business owners.
+            Integration showed what worked and what needed to change. I cleaned
+            up the code, finished the remaining behavior, wrote tests, and
+            documented the component. We kept checking the result against the
+            original goal: make payroll simpler for small business owners.
           </p>
         </div>
         <video
@@ -241,7 +218,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           playsinline
           loop
           muted
-          class="w-full h-full md:row-start-4 md:row-span-4 md:col-start-7 md:col-span-6"
+          class="min-w-0 w-full h-auto self-start md:row-start-2 md:row-span-2 md:col-start-8 md:col-span-5"
         >
           <source src={rollVideo} type="video/mp4" />
           Sorry, your browser doesn't support embedded videos. <a
@@ -249,33 +226,23 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site)
           >.
         </video>
         <div
-          class="md:row-start-8 md:row-span-4 md:col-start-3 md:col-span-7 flow case-panel z-10"
+          class="min-w-0 md:row-start-3 md:col-start-1 md:col-span-6 self-start flow case-panel z-10"
         >
-          <h3>The Results</h3>
+          <h3>Thirty Seconds a Week</h3>
           <p>
-            The outcome of our efforts was a robust, accessible, and intuitive
-            design solution that streamlined the payroll management process. We
-            had successfully transformed a complex task into an experience as
-            simple as engaging with a chat interface.
+            Roll turned a dense payroll process into a focused mobile flow. The
+            accordion kept the common work close and the unusual details within
+            reach.
           </p>
           <p>
-            By simplifying payroll management into an easy, mobile-first
-            experience, we helped Roll by ADP set a new standard for
-            user-centric design in financial applications. The feedback from
-            customers using the platform has been overwhelmingly positive,
-            confirming that we didn't just make payroll easier &mdash; we
-            transformed it into a task that could be handled on the go, with
-            just a few taps on a phone. The principal goal of Roll by ADP was to
-            be invisible. On average, our customers are only in our app for 30
-            seconds a week.
+            Roll's goal was to be almost invisible. Customers spent about 30
+            seconds a week in the app, on average. That is the result I care
+            about here. People could finish payroll and get back to running
+            their business.
           </p>
           <p>
-            This project represents how thoughtful user experience, coupled with
-            cutting-edge technology stacks, can revolutionize even the most
-            complex business processes. From discovery to implementation, every
-            step was taken with the end-user in mind, resulting in a solution
-            that truly meets the needs of small business owners in today's
-            fast-paced, mobile-first world.
+            The component also gave the team a reusable way to handle dense
+            employee data without designing every payroll workflow from scratch.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Rewrites the portfolio index and six detailed case studies in Frank's plainspoken voice. The new copy names the problem, decisions, tradeoffs, and results without corporate filler or unsupported claims.

The shorter stories also exposed brittle grid behavior. Explicit column definitions and simpler row placement now prevent the large vertical gaps and horizontal overflow found during review.

## What changed

- Tightened the phone number input, Ascent documentation, Roll, Loumarc Signs, Builders Trust Capital, and Simpson Strong-Tie case studies.
- Moved portfolio titles and headings to sentence case.
- Removed joined word dashes from prose except where an official name requires one.
- Corrected affected grid definitions, panel placement, and image text.

## Validation

- `npm test -- --run` — 19 tests passed.
- `npm run build` — Astro reported 0 errors, warnings, or hints and completed the production build.
- Reviewed every changed portfolio route in the local browser. The affected layouts showed no horizontal overflow, and the shortened panels kept their intended rhythm.

## Related

No linked issue.
